### PR TITLE
Add frontend-design generation references

### DIFF
--- a/packages/skills/frontend-design/SKILL.md
+++ b/packages/skills/frontend-design/SKILL.md
@@ -9,6 +9,16 @@ Use this as the design-lead layer for COMPOSE work. It shapes HTML/SVG motion gr
 
 This skill does not pick the video production line, replace `video-craft`, or relax HyperFrames/OVS renderer constraints. If there is a conflict, renderer determinism, safe zones, legibility, audio ownership, and user-approved creative direction win.
 
+## Required generation references
+
+For every non-trivial COMPOSE deliverable, read these compact references before authoring HTML:
+
+- `references/html-generation-playbook.md` — the private pre-code art-direction pass, frame-composition rules, and opening/resolved-state authoring pattern.
+- `references/visual-primitives.md` — reusable CSS/SVG composition primitives and scene-grammar selection guidance.
+- `references/worked-compositions.md` — worked examples showing how subject matter becomes a cohesive visual system without copying a fixed template.
+
+These references improve the initial generation. They do not create a new artifact, user gate, or approval step. Keep the art-direction pass internal and record only the decisions needed to make `design-contract.json` executable.
+
 ## Design Thesis
 
 Before writing HTML, choose a compact visual thesis:

--- a/packages/skills/frontend-design/references/html-generation-playbook.md
+++ b/packages/skills/frontend-design/references/html-generation-playbook.md
@@ -1,0 +1,103 @@
+# HTML generation playbook
+
+Use this during the initial COMPOSE generation, after the brief/storyboard is approved and before writing `index.html`. This is an internal authorship pass, not a user gate and not a new required project file.
+
+## Private pre-code art direction
+
+For the whole piece, decide five things before coding:
+
+1. **Material world** — list the real artifacts, surfaces, marks, diagrams, interfaces, documents, objects, or physical behaviors that belong to the topic. Prefer those over generic circles and lines.
+2. **Recurring carrier** — choose one visual object that can move through the story: signal, rule, token stream, document strip, route, waveform, product surface, cursor, scale, or data mark.
+3. **Type behavior** — choose how display, supporting copy, labels, and data differ through family/width/weight/case/tracking, not size alone.
+4. **Spatial rhythm** — alternate where the dominant mass lives. A sequence can move left-heavy → full-field → right-heavy → centered payoff; it should not reset to the same top-left title layout each time.
+5. **Motion logic** — decide what information is established, explained, and resolved. Motion must change meaning or state, not merely prove that animation exists.
+
+For every scene, internally answer:
+
+- What single visual object explains this beat without narration?
+- Where does the largest visual mass sit, and how much of the safe canvas does it occupy?
+- What are the background, midground, and foreground layers?
+- What is already visible on the first frame of the scene?
+- What new understanding exists in the resolved frame?
+- What enters from the previous scene and what leaves for the next one?
+- Which primitive or custom SVG construction will implement it?
+
+Put compact answers in the existing design contract scene fields when they help HTML execution. Do not create a separate approval artifact.
+
+## Compose a frame, not a page
+
+A good video frame remains intentional when paused:
+
+- Use asymmetric tension, scale contrast, edge anchoring, cropping, overlap, or a strong full-field structure. Do not center every object inside generous web-page whitespace.
+- Let meaningful material occupy the canvas. Empty space is useful only when it creates direction, suspense, scale, or emphasis.
+- Use three semantic depth layers. Background structure should belong to the subject; midground carries the main message; foreground annotations, ticks, fragments, or masks create scale and finish.
+- Build one dominant focal point and one supporting focal point. Tiny labels scattered around a small diagram do not create hierarchy.
+- Prefer a few large shapes and readable annotations over many small cards. At phone size, labels must remain legible and the hero graphic must still read as a silhouette.
+- Treat exact words, dates, numbers, and CTA copy as real HTML. Use SVG for geometry, relationships, paths, masks, charts, and spatial systems.
+
+## Opening, explanation, resolved
+
+Every scene needs three authored states:
+
+1. **Opening** — the premise and visual identity are already visible. The first scene must never be a blank canvas waiting for a fade.
+2. **Explanation** — structure, comparison, connection, or causality becomes visible in a controlled sequence.
+3. **Resolved** — the completed idea holds long enough to read and should be visibly different from the opening state.
+
+Author the resolved state first in HTML/CSS/SVG, then decide which parts begin muted, clipped, offset, or incomplete. Avoid building a scene whose only change is container opacity.
+
+For the first scene:
+
+```js
+// The opening composition is visible at t=0. Animate supporting structure,
+// not the whole scene from a blank frame.
+tl.set('#s01', { opacity: 1 }, 0)
+  .fromTo('#s01 .signal',
+    { strokeDashoffset: 720 },
+    { strokeDashoffset: 0, duration: 1.2, ease: 'power2.out' }, 0)
+  .fromTo('#s01 .annotation',
+    { opacity: 0.25, y: 18 },
+    { opacity: 1, y: 0, duration: 0.65, stagger: 0.08 }, 0.25);
+```
+
+For later scenes, a hard cut, wipe, carried object, or short crossfade may reveal the next scene at its start. Do not spend the first second of every scene fading an empty layout into view.
+
+## Scene variation without random style changes
+
+Keep typography, palette, stroke character, corner treatment, and the recurring carrier consistent. Vary two or more of these per scene:
+
+- dominant mass position;
+- full-field versus split composition;
+- visual grammar: document, path, network, comparison, scale, object, quote;
+- camera/framing: macro crop, overview, detail, centered payoff;
+- motion behavior: draw, reveal, accumulate, transform, converge;
+- relationship between text and visual: integrated, adjacent, overprinted, annotated.
+
+Variation is structural, not a new palette or unrelated visual style every few seconds.
+
+## Generation-time anti-patterns
+
+Replace these before coding:
+
+- `top-left headline + small diagram below` repeated across the sequence;
+- a pure-color background with only one thin SVG group;
+- four words placed around a circle as a substitute for an explanation;
+- multiple diagonal lines without scale, anchors, values, or change over time;
+- universal Arial/Helvetica with no meaningful role contrast;
+- all scene roots fading from opacity zero;
+- a final frame that is identical to the prior scene midpoint;
+- arbitrary decorative particles, blobs, cards, grids, or glows unrelated to the topic.
+
+## Initial-generation checklist
+
+Before saving `index.html`, verify from the source itself:
+
+- frame 0 contains the promise and a subject-specific visual signal;
+- every scene has background, midground, and foreground intent;
+- each scene has a large, recognizable hero visual;
+- the spatial sequence varies without losing the shared visual system;
+- opening and resolved states differ meaningfully;
+- one carrier or motif creates continuity across the piece;
+- typography roles differ beyond font size;
+- SVG structure encodes real content rather than generic decoration;
+- no remote runtime dependency is required;
+- animation is deterministic and registered on the paused GSAP timeline.

--- a/packages/skills/frontend-design/references/visual-primitives.md
+++ b/packages/skills/frontend-design/references/visual-primitives.md
@@ -1,0 +1,231 @@
+# Video visual primitives
+
+These are adaptable ingredients for model-authored HTML, not fixed templates. Select only the primitives justified by the brief, then change geometry, scale, copy, density, and motion to fit the subject.
+
+## 1. Composition chassis
+
+Use a shared token chassis so scenes feel related while their layouts vary:
+
+```css
+:root {
+  --bg: #081018;
+  --ink: #f3f0e8;
+  --muted: #9ca8b4;
+  --accent: #ffb000;
+  --support: #55d6c2;
+  --danger: #ff665c;
+  --safe-x: 112px;
+  --safe-y: 92px;
+  --hairline: 2px;
+}
+
+* { box-sizing: border-box; }
+html, body { width: 1920px; height: 1080px; overflow: hidden; margin: 0; }
+body {
+  color: var(--ink);
+  background: var(--bg);
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+}
+.scene {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  isolation: isolate;
+}
+.safe { position: absolute; inset: var(--safe-y) var(--safe-x); }
+.display {
+  font-size: clamp(76px, 6.1vw, 118px);
+  line-height: .9;
+  font-weight: 760;
+  letter-spacing: -.055em;
+}
+.supporting {
+  max-width: 720px;
+  font-size: 42px;
+  line-height: 1.16;
+  color: var(--muted);
+}
+.label {
+  font-size: 38px;
+  line-height: 1;
+  font-weight: 650;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+```
+
+Derive tokens from the design contract. Do not paste this palette into unrelated work.
+
+## 2. Topic-derived background field
+
+A background field establishes material and depth without becoming a dashboard:
+
+```css
+.field::before {
+  content: "";
+  position: absolute;
+  inset: -8%;
+  z-index: -2;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--ink) 7%, transparent) 1px, transparent 1px),
+    linear-gradient(color-mix(in srgb, var(--ink) 5%, transparent) 1px, transparent 1px);
+  background-size: 96px 96px;
+  mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent);
+}
+.field::after {
+  content: "";
+  position: absolute;
+  width: 820px;
+  height: 820px;
+  right: -240px;
+  top: 80px;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--accent) 18%, transparent), transparent 68%);
+  filter: blur(24px);
+  z-index: -1;
+}
+```
+
+Adapt the field to the topic: manuscript rules, map coordinates, spectral bands, film grain, product geometry, waveform lanes, token cells, or measured laboratory ticks. A generic grid is not automatically appropriate.
+
+## 3. Asymmetric split
+
+Use for an argument plus one substantial visual:
+
+```css
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, .78fr) minmax(0, 1.22fr);
+  gap: 88px;
+  align-items: center;
+  height: 100%;
+}
+.split[data-mass="left"] { grid-template-columns: 1.25fr .75fr; }
+.split__visual { min-height: 700px; position: relative; }
+```
+
+The visual zone should contain a real diagram, object, image crop, chart, or structural typographic composition. Do not place a small icon in a large empty column.
+
+## 4. Editorial title wall
+
+Use an oversized, edge-anchored title plus subject evidence—not a centered hero card:
+
+```css
+.title-wall .display {
+  position: absolute;
+  left: var(--safe-x);
+  bottom: 138px;
+  width: 78%;
+  font-size: 142px;
+}
+.title-wall .ghost {
+  position: absolute;
+  right: 70px;
+  top: 22px;
+  font-size: 330px;
+  line-height: 1;
+  font-weight: 800;
+  color: color-mix(in srgb, var(--ink) 5%, transparent);
+  letter-spacing: -.08em;
+}
+.title-wall .evidence {
+  position: absolute;
+  right: var(--safe-x);
+  top: 118px;
+  width: 560px;
+  min-height: 260px;
+  border-top: var(--hairline) solid var(--accent);
+}
+```
+
+`evidence` can be a paper excerpt, product crop, map, data mark, waveform, or diagram fragment that proves the subject immediately.
+
+## 5. SVG signal carrier
+
+Use one path to carry continuity across scenes. Author the resolved path in SVG and animate `stroke-dashoffset`:
+
+```html
+<svg class="carrier" viewBox="0 0 1200 620" aria-hidden="true">
+  <path class="carrier__guide" d="M40 480 C260 80 430 560 650 220 S980 120 1160 300" />
+  <path class="carrier__signal" pathLength="1"
+        d="M40 480 C260 80 430 560 650 220 S980 120 1160 300" />
+  <g class="carrier__marks">
+    <circle cx="40" cy="480" r="10" />
+    <circle cx="650" cy="220" r="10" />
+    <circle cx="1160" cy="300" r="10" />
+  </g>
+</svg>
+```
+
+```css
+.carrier__guide { fill: none; stroke: color-mix(in srgb, var(--ink) 13%, transparent); stroke-width: 2; }
+.carrier__signal { fill: none; stroke: var(--accent); stroke-width: 7; stroke-linecap: round; stroke-dasharray: 1; stroke-dashoffset: 1; }
+.carrier__marks circle { fill: var(--bg); stroke: var(--ink); stroke-width: 3; }
+```
+
+Change the path into a route, reading order, waveform, parameter curve, product flow, or narrative thread. It must encode meaning.
+
+## 6. Measured comparison field
+
+Comparisons need scale and anchors, not unlabeled diagonal lines:
+
+```html
+<svg viewBox="0 0 1100 640" class="measure" aria-hidden="true">
+  <g class="measure__grid">
+    <path d="M120 60V560H1040" />
+    <path d="M120 435H1040M120 310H1040M120 185H1040" />
+  </g>
+  <g class="measure__bars">
+    <rect x="210" y="430" width="150" height="130" rx="4" />
+    <rect x="470" y="300" width="150" height="260" rx="4" />
+    <rect x="730" y="105" width="150" height="455" rx="4" />
+  </g>
+</svg>
+```
+
+Place exact values and labels as nearby HTML text. Animate bars, range fills, or paths from a common baseline, then hold the completed comparison.
+
+## 7. Document-to-diagram transformation
+
+For research, history, policy, or technical explanations:
+
+- Start from a large cropped document fragment or typographic excerpt.
+- Highlight one phrase, equation, heading, or date.
+- Extend rules/connectors from that evidence into the explanatory diagram.
+- Preserve one fragment as foreground context while the diagram resolves.
+
+This is stronger than replacing the source with a generic network graphic.
+
+## 8. Convergence field
+
+For multimodal, systems, ecosystems, or synthesis:
+
+- Give each input its own material behavior, not just a word around a circle.
+- Text can arrive as token rows; audio as a measured waveform; image as crop tiles; code as aligned syntax bands.
+- Let inputs bend, mask, or recompose into one shared output object.
+- Resolve into a new state that visibly contains evidence of all inputs.
+
+## 9. Deterministic motion recipes
+
+Use a small number of semantic groups:
+
+```js
+// Establish -> explain -> resolve -> hold.
+tl.set(scene, { opacity: 1 }, start)
+  .fromTo(`${id} .structure`, { opacity: .35 }, { opacity: 1, duration: .55 }, start)
+  .fromTo(`${id} .build`, { strokeDashoffset: 1 }, { strokeDashoffset: 0, duration: 1.25 }, start + .18)
+  .fromTo(`${id} .result`, { opacity: 0, y: 22 }, { opacity: 1, y: 0, duration: .65 }, start + 1.05);
+```
+
+Use explicit timeline positions. CSS animations, timers, random particles, and runtime network calls are not render-safe.
+
+## Primitive selection guide
+
+- Research/history: editorial title wall + document-to-diagram + signal carrier.
+- Data/scale: measured comparison + full-field data mark + annotated path.
+- Product/feature: product surface + asymmetric split + cursor/route carrier.
+- Systems/process: map/flow + convergence field + state transformation.
+- Quote/argument: oversized type + evidence fragment + rule/annotation system.
+- Abstract concept: choose a concrete physical behavior first—accumulation, compression, branching, collision, alignment, or convergence—then build custom SVG around it.
+
+Do not use all primitives in one scene. One scene grammar, one hero visual, one supporting system, and one continuity carrier are usually enough.

--- a/packages/skills/frontend-design/references/worked-compositions.md
+++ b/packages/skills/frontend-design/references/worked-compositions.md
@@ -1,0 +1,84 @@
+# Worked composition references
+
+Use these as reasoning examples, not layouts to copy. Preserve the method—extract subject materials, choose a carrier, vary spatial grammar, author resolved states—while changing the actual design for each brief.
+
+## Example 1: A short history of large language models
+
+**Weak default:** dark background, top-left heading, one generic diagram per scene, yellow circles and lines everywhere.
+
+**Subject materials:** paper typography, token rows, attention matrices, parameter scales, chat turns, image crops, waveforms, syntax bands.
+
+**Visual system:** near-black research desk; warm paper-white type; amber signal as the historical carrier; mint/red only for meaningful comparison. Display type is dense and editorial, labels are measured and technical.
+
+**Sequence:**
+
+1. Title wall: a giant cropped `2017` sits behind the title; a Transformer paper fragment occupies the right third; the amber signal is already visible at frame 0.
+2. Attention: the paper fragment expands into a full-height attention matrix; token rows activate and contextual arcs resolve over it.
+3. Scaling: the same amber path becomes a measured logarithmic climb with anchored model eras, exact values, and a large terminal data mark.
+4. Chat: the path straightens into a cursor rail; two oversized conversational turns displace the prior chart rather than appearing inside small UI cards.
+5. Multimodal: text rows, image crop tiles, waveform bands, and code columns arrive with different material behaviors and converge into one field.
+6. Payoff: the four materials remain visible inside a unified output object while the thesis resolves in large type. The final frame is not a copy of the prior midpoint.
+
+**Why it works:** every scene uses content evidence, the amber carrier provides continuity, and the spatial mass moves from split to full-field to measured comparison to centered convergence.
+
+## Example 2: Product feature launch
+
+**Weak default:** floating browser card, gradient background, three benefit cards, logo and CTA.
+
+**Subject materials:** actual product surface, cursor path, before/after states, real output, brand typography and tokens.
+
+**Visual system:** the product itself occupies 55–75% of the frame. Supporting copy is edge-anchored and never competes with the interface. A cursor/selection path carries the story.
+
+**Sequence:**
+
+1. Open on the finished outcome at full scale, not a logo fade.
+2. Pull back to reveal the product surface and the one action that produced it.
+3. Use a cropped before/after split with one continuous cursor path crossing the divider.
+4. Resolve into the product's output plus one concise proof point.
+
+**Why it works:** the product is the hero visual; graphics explain interaction and outcome instead of wrapping the product in generic marketing decoration.
+
+## Example 3: Data-led explainer
+
+**Weak default:** dashboard grid with many tiny charts and metric cards.
+
+**Subject materials:** one decisive comparison, exact values, baseline, range, annotation, category shape.
+
+**Visual system:** one data mark dominates each scene. Supporting values are large HTML text. Grid lines and ticks are sparse, measured, and consistent.
+
+**Sequence:**
+
+1. Open with the surprising number as a large physical mass beside a clear denominator.
+2. Reveal the baseline and comparison categories from the same origin.
+3. Transform the dominant bar/path into the next scene's scale rather than cutting to a new dashboard.
+4. Resolve with the implication in type while the complete chart remains visible.
+
+**Why it works:** data has tangible visual weight; the audience sees a relationship, not a collection of interface widgets.
+
+## Example 4: Abstract systems concept
+
+**Weak default:** four labeled nodes around a glowing center.
+
+**Subject materials:** pick a physical behavior that matches the argument—branching, compression, collision, sorting, accumulation, or convergence.
+
+**Visual system:** each input has a different geometry and motion behavior. The center is not meaningful until the inputs visibly change it.
+
+**Sequence for convergence:**
+
+1. Inputs already occupy distinct edges of frame 0.
+2. Each input crosses a measured boundary and changes form.
+3. Intermediate relationships become visible through paths, masks, or shared alignment.
+4. The resolved object contains recognizable traces of every input.
+
+**Why it works:** the animation demonstrates the concept. Labels support the transformation rather than substituting for it.
+
+## Applying the examples
+
+Before generating HTML, write a one-line comparison internally:
+
+```text
+The weak default would be [generic composition]; this brief instead uses
+[subject material] as [hero visual] and carries [recurring object] across scenes.
+```
+
+If that sentence could describe any topic, the direction is still too generic. Revise it before coding.

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,1 +1,1 @@
-{"name":"@orkas/video-studio-skills","version":"0.0.0","private":false,"files":["*/SKILL.md"]}
+{"name":"@orkas/video-studio-skills","version":"0.0.0","private":false,"files":["*/SKILL.md","*/references/*.md"]}


### PR DESCRIPTION
## Why

PR #2 moved `frontend-design/SKILL.md` into the OSS skill pack but dropped the `references/` subdir it points at. The compose-time art-direction pass therefore had no playbook, primitive catalog, or worked examples to read — the skill referenced material that did not exist in this repo.

## What

- Add `packages/skills/frontend-design/references/`:
  - `html-generation-playbook.md` — pre-code art-direction pass, frame-composition rules, opening/resolved-state authoring.
  - `visual-primitives.md` — reusable CSS/SVG composition primitives and scene-grammar guidance.
  - `worked-compositions.md` — worked examples of subject → cohesive visual system.
- Add the `## Required generation references` pointer section to `SKILL.md` so the references are actually discovered at authoring time.
- Widen `packages/skills/package.json` `files` from `*/SKILL.md` to also include `*/references/*.md`, so the references ship with the published package rather than existing only in git.

## Provenance

Hand re-mapped from the upstream Orkas video-studio agent (`b62533b69`). The three references were already renderer-neutral (they speak in terms of the design contract, not any host-specific op protocol) and are added verbatim. Only the pointer section is reworded for this repo's `design-contract.json` / `ovs` flow.

## Verification

- `pnpm build` — green.
- `pnpm test` — 128 passed / 8 skipped, unchanged from base.
- Leak scan for host-internal markers (agent ids, `ownerAgent`, native tool names, `art_direction` manifest fields): clean.

Docs/prompt content only; no runtime code paths touched.