### PR TITLE
Drop vendored upstream lookup paths

### DIFF
--- a/packages/tools/src/render/composition-qa.ts
+++ b/packages/tools/src/render/composition-qa.ts
@@ -303,14 +303,16 @@ export async function loadShotlist(compositionDirAbs: string): Promise<JsonLoad>
   return readJsonIfExists(path.resolve(compositionDirAbs, '..', 'shotlist.json'));
 }
 
+/**
+ * Where the bundled GSAP can be found: next to the built output, next to the
+ * source when running from src, and from the repo root when cwd is the checkout.
+ */
 function packageVendorCandidates(): string[] {
   const here = path.dirname(fileURLToPath(import.meta.url));
   return [
     path.join(here, 'vendor', 'gsap.min.js'),
     path.resolve(here, '..', '..', 'src', 'render', 'vendor', 'gsap.min.js'),
     path.resolve(process.cwd(), 'packages', 'tools', 'src', 'render', 'vendor', 'gsap.min.js'),
-    path.resolve(process.cwd(), 'PC', 'resources', 'builtin', 'marketplace', 'agents', '79df9cc89f5f', 'skills', 'stage-compose', 'scripts', 'vendor', 'gsap.min.js'),
-    path.resolve(process.cwd(), 'resources', 'builtin', 'marketplace', 'agents', '79df9cc89f5f', 'skills', 'stage-compose', 'scripts', 'vendor', 'gsap.min.js'),
   ];
 }
 


### PR DESCRIPTION
> Independent of the #3–#7 stack — based directly on `main`. The hunk is ~200 lines from the one #5 touches in this file, so it merges either way.

## Why

`packageVendorCandidates()` carries two GSAP lookup paths that point into the private monorepo this agent was extracted from:

```
process.cwd()/PC/resources/builtin/marketplace/agents/<agent-id>/skills/stage-compose/scripts/vendor/gsap.min.js
process.cwd()/resources/builtin/marketplace/agents/<agent-id>/skills/stage-compose/scripts/vendor/gsap.min.js
```

Neither can exist in a checkout of this repo — this is a standalone package, not that monorepo — so they are dead lookups. They also spell out upstream's internal directory layout and its internal agent id in a public repo. They came in with the initial port (`07bc671`), which copied the candidate list verbatim.

## What

Remove the two dead paths and document what the remaining three are for: next to the built output, next to the source when running from `src`, and repo-root-relative when cwd is the checkout.

## Verification

- `pnpm build` green; `pnpm test` 128 passed / 8 skipped, unchanged from `main`.
- Checked the surviving candidates still resolve the real file against the built output location before removing anything — candidates 2 and 3 both hit `packages/tools/src/render/vendor/gsap.min.js`.
- `grep -rn '<agent-id>'` over the repo now returns nothing outside `dist/`.