### PR TITLE
Enforce the design contract before preview or draft

### DIFF
--- a/packages/skills/frontend-design/SKILL.md
+++ b/packages/skills/frontend-design/SKILL.md
@@ -159,7 +159,7 @@ When writing `index.html`:
 2. Self-critique the contract: name the most generic choice and replace it.
 3. Run the internal pre-code art-direction pass: choose `VisualDirectionV1`, scene grammar, hero visual, three depth layers, motion verbs, typography register, rhythm pattern, opening/resolved states, and cross-scene continuity. Keep it inside the generation turn; no new user confirmation.
 4. Write HTML/SVG from the contract using adapted visual primitives and worked examples as references, not fixed templates.
-5. Run `ovs draft ... --quality draft`. If structural, contract, source, audio, media, or sampled-frame QA fails, repair the contract or scene structure first; do not only nudge CSS numbers. Treat visual/readability findings as draft notes unless they make the approved message unreadable.
+5. Run `ovs draft ... --quality draft`. If structural, contract, source, audio, media, or sampled-frame QA fails, repair the contract or scene structure first; do not only nudge CSS numbers. Missing preview-required art direction is a blocking contract error, not a cosmetic note: `ovs draft` returns `E_DESIGN_CONTRACT_BLOCKED` until the aesthetic thesis, `VisualDirectionV1`, motion budget, scene variation budget, per-scene depth layers, and per-scene motion verbs are complete. Treat visual/readability findings as draft notes unless they make the approved message unreadable.
 6. After the draft report is written, judge the evidence frames/contact sheet for: clear focal point, subject-specific visual language, readable type, and motion with purpose.
 
 ## Output Standard

--- a/packages/skills/stage-compose/SKILL.md
+++ b/packages/skills/stage-compose/SKILL.md
@@ -153,6 +153,8 @@ The contract must declare these budgets compactly:
 
 The palette is a design contract, not a mechanical hue cap. The HTML/CSS/SVG should derive its main system from `color_tokens` through CSS variables or equivalent structured constants, but do not flatten or recolor a scene just to reduce a static color count.
 
+The contract is enforced, not advisory. `ovs snapshot`, `ovs lint`, `ovs inspect`, and `ovs draft` block or report when a declared contract lacks the preview-required budget — the aesthetic thesis, `visual_direction`, `motion_budget`, `scene_variation`, or per-scene `depth_layers` / `motion_verbs` — because those are what steer HTML authoring. Repair the contract and rerun; do not work around the gate. A composition that ships no `design-contract.json` is not checked, and `ovs render` stays raw for a work-in-progress composition.
+
 Run a pre-code anti-template check from `frontend-design`: name the first generic design move you rejected and the brief-specific replacement. If you cannot name that replacement, the contract is not ready. The check should catch lazy defaults before HTML: purple/blue neon, glowing black-background circles, centered equal-weight layouts, identical cards, decorative emoji/icons, tiny badges, web-dashboard fragments, pure black/white, and web-scale type. When `style_source` exists, also name what was adapted, simplified, and not copied from the reference.
 
 ## Inspect And Repair Policy

--- a/packages/tools/src/render/composition-qa.ts
+++ b/packages/tools/src/render/composition-qa.ts
@@ -538,6 +538,167 @@ function expectedCanvas(contract: unknown, sceneMap: unknown): { width: number; 
   };
 }
 
+/**
+ * The design contract's budget sections. A contract that declares none of these
+ * is not a budget, just a style note.
+ */
+const DESIGN_CONTRACT_SECTIONS = ['aesthetic', 'visual_direction', 'layout_boxes', 'typography_tokens', 'color_tokens', 'motion_budget', 'scene_variation'];
+
+/**
+ * The subset that has to be there before we spend a preview or a render: these
+ * are what actually steer HTML authoring. The rest degrade the output; these
+ * decide whether there is a design at all.
+ */
+const PREVIEW_REQUIRED_DESIGN_SECTIONS = new Set(['aesthetic', 'visual_direction', 'motion_budget', 'scene_variation']);
+
+const AESTHETIC_FIELDS = ['subject_world', 'one_job', 'signature_device', 'aesthetic_risk', 'anti_template_check'];
+const VISUAL_DIRECTION_FIELDS = ['visual_tradition', 'lazy_defaults_rejected', 'video_scale', 'depth_layer_rule', 'motion_verb_rule', 'rhythm_pattern'];
+
+/** Style words that sound like a thesis but constrain nothing. */
+const GENERIC_AESTHETIC_RE = /\b(?:modern tech|clean modern|sleek|premium|minimalist|minimal|futuristic|dynamic|engaging|professional|high[- ]end|beautiful|polished)\b/i;
+
+const HARD_PREVIEW_DESIGN_CODES = new Set([
+  'AESTHETIC_THESIS_INCOMPLETE',
+  'GENERIC_AESTHETIC_THESIS',
+  'VISUAL_DIRECTION_INCOMPLETE',
+  'SCENE_DEPTH_LAYERS_MISSING',
+  'SCENE_MOTION_VERBS_MISSING',
+]);
+
+function designSeverity(code: string, hard = true): Issue['severity'] {
+  if (code === 'DESIGN_CONTRACT_BUDGET_INCOMPLETE') return hard ? 'error' : 'warning';
+  return HARD_PREVIEW_DESIGN_CODES.has(code) ? 'error' : 'warning';
+}
+
+/** Present and substantive — a 2-character placeholder is not a decision. */
+function hasContent(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim().length >= 4;
+  if (Array.isArray(value)) return value.length > 0;
+  if (isRecord(value)) return Object.values(value).some(hasContent);
+  return value !== null && value !== undefined && value !== false;
+}
+
+function designTextFrom(value: unknown): string {
+  const out: string[] = [];
+  const walk = (node: unknown, depth: number): void => {
+    if (depth > 6 || node === null || node === undefined) return;
+    if (typeof node === 'string') { out.push(node); return; }
+    if (Array.isArray(node)) { for (const item of node) walk(item, depth + 1); return; }
+    if (isRecord(node)) for (const item of Object.values(node)) walk(item, depth + 1);
+  };
+  walk(value, 0);
+  return out.join(' ');
+}
+
+/**
+ * Check a design contract against the budget it claims to be, before a preview
+ * or render is spent on it.
+ *
+ * Only compositions that actually ship a `design-contract.json` are held to
+ * this: no contract means no opinion, so raw HyperFrames projects and plain
+ * renders are untouched. Errors here are what make the "repair the contract
+ * first" rule in stage-compose real rather than advice.
+ *
+ * Pure → fixtured for complete, thin, and look-alike contracts.
+ */
+export function designContractIssues(contract: unknown, sceneMap: unknown, selector = 'design-contract.json'): Issue[] {
+  if (!isRecord(contract)) return [];
+  const issues: Issue[] = [];
+
+  const missingSections = DESIGN_CONTRACT_SECTIONS.filter((key) => !hasContent(contract[key]));
+  if (missingSections.length) {
+    const code = 'DESIGN_CONTRACT_BUDGET_INCOMPLETE';
+    const missingPreviewRequired = missingSections.filter((key) => PREVIEW_REQUIRED_DESIGN_SECTIONS.has(key));
+    issues.push({
+      code,
+      severity: designSeverity(code, missingPreviewRequired.length > 0),
+      selector,
+      message: `Design contract is missing aesthetic budget fields: ${missingSections.join(', ')}.`,
+      fixHint: 'Add compact aesthetic, visual-direction, layout, type, color, motion, and scene-variation budgets before writing HTML.',
+      source: 'ovs-design-contract',
+    });
+  }
+
+  const aesthetic = isRecord(contract.aesthetic) ? contract.aesthetic : {};
+  // frontend-design documents anti_template_check; older contracts wrote
+  // anti_template. Treat them as aliases so a real thesis is not reported
+  // missing over a field-name drift.
+  const aestheticForChecks: Record<string, unknown> = {
+    ...aesthetic,
+    anti_template_check: hasContent(aesthetic.anti_template_check) ? aesthetic.anti_template_check : aesthetic.anti_template,
+  };
+  const missingAesthetic = AESTHETIC_FIELDS.filter((key) => !hasContent(aestheticForChecks[key]));
+  if (hasContent(contract.aesthetic) && missingAesthetic.length) {
+    const code = 'AESTHETIC_THESIS_INCOMPLETE';
+    issues.push({
+      code,
+      severity: designSeverity(code),
+      selector: `${selector}#aesthetic`,
+      message: `Aesthetic thesis is too thin for distinctive HTML: ${missingAesthetic.join(', ')} missing.`,
+      fixHint: 'Name the subject-specific visual world, signature device, risk, and rejected generic move.',
+      source: 'ovs-design-contract',
+    });
+  }
+
+  const aestheticText = designTextFrom(aesthetic);
+  if (aestheticText && GENERIC_AESTHETIC_RE.test(aestheticText) && !hasContent(aesthetic.signature_device)) {
+    const code = 'GENERIC_AESTHETIC_THESIS';
+    issues.push({
+      code,
+      severity: designSeverity(code),
+      selector: `${selector}#aesthetic`,
+      message: 'Aesthetic thesis uses generic style language without a concrete signature device.',
+      fixHint: 'Replace generic descriptors with a visual behavior that belongs to this brief.',
+      source: 'ovs-design-contract',
+    });
+  }
+
+  const visualDirection = isRecord(contract.visual_direction) ? contract.visual_direction : {};
+  const missingVisualDirection = VISUAL_DIRECTION_FIELDS.filter((key) => !hasContent(visualDirection[key]));
+  if (hasContent(contract.visual_direction) && missingVisualDirection.length) {
+    const code = 'VISUAL_DIRECTION_INCOMPLETE';
+    issues.push({
+      code,
+      severity: designSeverity(code),
+      selector: `${selector}#visual_direction`,
+      message: `Visual direction is missing pre-authoring fields: ${missingVisualDirection.join(', ')}.`,
+      fixHint: 'Name the design tradition, rejected lazy defaults, video-scale rule, depth-layer rule, motion-verb rule, and rhythm pattern before HTML authoring.',
+      source: 'ovs-design-contract',
+    });
+  }
+
+  // Per-scene design plan: prefer the contract's own scenes, fall back to the
+  // scene map when the contract does not restate them.
+  const scenes = extractScenes(contract).length ? extractScenes(contract) : extractScenes(sceneMap);
+  const missingDepth = scenes.filter((scene) => !hasContent(scene.depth_layers)).slice(0, 4);
+  if (scenes.length && missingDepth.length) {
+    const code = 'SCENE_DEPTH_LAYERS_MISSING';
+    issues.push({
+      code,
+      severity: designSeverity(code),
+      selector: `${selector}#scenes`,
+      message: `Scene art direction is missing background/midground/foreground depth layers for ${missingDepth.map(sceneLabel).join(', ')}.`,
+      fixHint: 'Give each scene a topic-derived background, a dominant midground, and foreground accents.',
+      source: 'ovs-design-contract',
+    });
+  }
+
+  const missingVerbs = scenes.filter((scene) => !hasContent(scene.motion_verbs) && !hasContent(scene.motion_choreography)).slice(0, 4);
+  if (scenes.length && missingVerbs.length) {
+    const code = 'SCENE_MOTION_VERBS_MISSING';
+    issues.push({
+      code,
+      severity: designSeverity(code),
+      selector: `${selector}#scenes`,
+      message: `Scene art direction is missing motion verbs for ${missingVerbs.map(sceneLabel).join(', ')}.`,
+      fixHint: 'Say what each primary element does: draws, stamps, counts up, locks, drifts, resolves.',
+      source: 'ovs-design-contract',
+    });
+  }
+
+  return issues;
+}
+
 function extractScenes(value: unknown): Array<Record<string, unknown>> {
   if (Array.isArray(value)) return value.filter(isRecord);
   if (!isRecord(value)) return [];

--- a/packages/tools/src/render/render.ts
+++ b/packages/tools/src/render/render.ts
@@ -13,6 +13,7 @@ import { lintCompositionCraft, type CraftFinding } from './craft-lint.js';
 import {
   buildDraftFrameSamplePlan,
   buildPreviewSamplePlan,
+  designContractIssues,
   findingsJson,
   initDraftRepairBudget,
   loadCompositionMeta,
@@ -114,7 +115,8 @@ export type DraftResult =
 
 /** Render a HyperFrames composition directory to a video file via `npx hyperframes render`. */
 export async function render(params: RenderParams): Promise<RenderResult> {
-  await assertLocalCompositionPreflight(resolve(params.project), 'composition.render');
+  // Structural checks only: `render` is the raw renderer, not a design gate.
+  await assertLocalCompositionPreflight(resolve(params.project), 'composition.render', false);
   const npx = npxOrThrow();
   const env = buildHyperframesEnv(resolveFfmpegTools());
   const quality = params.quality ?? 'high';
@@ -208,9 +210,15 @@ async function qa(op: 'lint' | 'inspect', project: string, signal?: AbortSignal)
   return mergePreflightQa(preflight, withCraft);
 }
 
-async function localCompositionPreflight(project: string): Promise<{ errorCount: number; warningCount: number; issues: Issue[]; payload: Record<string, unknown> }> {
-  const loaded = await loadCompositionMeta(resolve(project));
-  const issues = loaded.issues;
+/**
+ * @param design Also hold a declared design contract to its budget. On for the
+ *   design surfaces (preview snapshot, lint/inspect); off for `render`, which is
+ *   the raw renderer and must stay usable on a work-in-progress composition.
+ */
+async function localCompositionPreflight(project: string, design = true): Promise<{ errorCount: number; warningCount: number; issues: Issue[]; payload: Record<string, unknown> }> {
+  const projectAbs = resolve(project);
+  const loaded = await loadCompositionMeta(projectAbs);
+  const issues = [...loaded.issues, ...(design ? await localDesignIssues(projectAbs) : [])];
   const errorCount = issues.filter((issue) => issue.severity === 'error').length;
   const warningCount = issues.filter((issue) => issue.severity === 'warning').length;
   const payload = JSON.parse(findingsJson(issues, {
@@ -221,8 +229,16 @@ async function localCompositionPreflight(project: string): Promise<{ errorCount:
   return { errorCount, warningCount, issues, payload };
 }
 
-async function assertLocalCompositionPreflight(project: string, op: string): Promise<void> {
-  const preflight = await localCompositionPreflight(project);
+/** Design issues for a composition that ships a contract; none if it does not. */
+async function localDesignIssues(projectAbs: string): Promise<Issue[]> {
+  const contractLoad = await loadDesignContract(projectAbs).catch(() => null);
+  if (!contractLoad?.exists) return [];
+  const sceneMapLoad = await loadSceneMap(projectAbs).catch(() => null);
+  return designContractIssues(contractLoad.value, sceneMapLoad?.value ?? null);
+}
+
+async function assertLocalCompositionPreflight(project: string, op: string, design = true): Promise<void> {
+  const preflight = await localCompositionPreflight(project, design);
   if (preflight.errorCount === 0) return;
   const first = preflight.issues.find((issue) => issue.severity === 'error');
   throw new Error(`${op} blocked by local composition preflight: ${first?.code || 'COMPOSITION_INVALID'} ${first?.message || ''}`.trim());
@@ -651,6 +667,22 @@ export async function draft(params: DraftParams): Promise<DraftResult> {
     scene_map_path: sceneMapLoad.exists ? sceneMapLoad.path : '',
     shotlist_path: shotlistLoad.exists ? shotlistLoad.path : '',
   };
+
+  // A declared contract has to be a usable budget before a render is spent on
+  // it. Repairing the contract is cheap; a draft rendered from a thin one is not.
+  const designIssues = designContractIssues(contractLoad.value, sceneMapLoad.value);
+  const designErrors = designIssues.filter((issue) => issue.severity === 'error');
+  steps.design_contract = {
+    ok: designErrors.length === 0,
+    op: 'composition.design_contract',
+    findings: findingsJson(designIssues, { engine: 'ovs-design-contract', profile: 'orkas-html-composition' }),
+  };
+  if (designErrors.length > 0) {
+    return failDraft(report, params, 'E_DESIGN_CONTRACT_BLOCKED', 'design contract is too thin to guide HTML authoring.', {
+      repair_target: designErrors[0]?.selector || 'design-contract.json',
+      design_summary: { error_count: designErrors.length, issues: designErrors.slice(0, 12) },
+    }, repairBudget);
+  }
 
   const contractHtml = await runContractHtmlQa(loaded.meta, loaded.issues, contractLoad, sceneMapLoad, project);
   steps.contract_html = contractHtml;

--- a/packages/tools/test/design-contract.test.ts
+++ b/packages/tools/test/design-contract.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { designContractIssues } from '../src/render/composition-qa';
+
+const FULL = {
+  aesthetic: {
+    subject_world: 'battery lab oscilloscope traces',
+    one_job: 'show the charge curve flattening',
+    signature_device: 'the trace becomes the progress line',
+    aesthetic_risk: 'no product shot until the payoff',
+    anti_template_check: 'rejected a centered title card',
+  },
+  visual_direction: {
+    visual_tradition: 'Swiss Pulse precision grid',
+    lazy_defaults_rejected: 'rejected neon circles; using instrument traces',
+    video_scale: '1920x1080: headline 88-132px, body 44-56px',
+    depth_layer_rule: 'BG grid, MG trace, FG metadata ticks',
+    motion_verb_rule: 'the trace draws, the value counts up',
+    rhythm_pattern: 'hook-build-HOLD-resolve',
+  },
+  layout_boxes: { focal: 'left two thirds' },
+  typography_tokens: { title: '96px', body: '44px' },
+  color_tokens: { bg: '#081018' },
+  motion_budget: 'the trace draws once; everything else holds still',
+  scene_variation: 'no two adjacent scenes share a layout grammar',
+  scenes: [{ id: 's1', depth_layers: 'BG grid / MG trace / FG ticks', motion_verbs: 'trace draws' }],
+};
+
+const codes = (issues: ReturnType<typeof designContractIssues>) => issues.map((i) => i.code);
+const errors = (issues: ReturnType<typeof designContractIssues>) => issues.filter((i) => i.severity === 'error');
+
+describe('designContractIssues', () => {
+  it('passes a contract that meets its budget', () => {
+    expect(designContractIssues(FULL, null)).toEqual([]);
+  });
+
+  it('has no opinion when there is no contract', () => {
+    expect(designContractIssues(null, null)).toEqual([]);
+    expect(designContractIssues(undefined, null)).toEqual([]);
+    // A scene map alone must not conjure design findings.
+    expect(designContractIssues(null, { scenes: [{ id: 's1' }] })).toEqual([]);
+  });
+
+  it('blocks when preview-required budget sections are absent', () => {
+    const { aesthetic, visual_direction, motion_budget, scene_variation, ...rest } = FULL;
+    const issues = designContractIssues(rest, null);
+    expect(codes(issues)).toContain('DESIGN_CONTRACT_BUDGET_INCOMPLETE');
+    expect(errors(issues).length).toBeGreaterThan(0);
+  });
+
+  it('only warns when the absent sections are not preview-required', () => {
+    const { layout_boxes, color_tokens, ...rest } = FULL;
+    const issues = designContractIssues(rest, null);
+    expect(codes(issues)).toEqual(['DESIGN_CONTRACT_BUDGET_INCOMPLETE']);
+    expect(errors(issues)).toEqual([]);
+  });
+
+  it('blocks a thesis that is present but hollow', () => {
+    const issues = designContractIssues({ ...FULL, aesthetic: { subject_world: 'a lab' } }, null);
+    expect(codes(issues)).toContain('AESTHETIC_THESIS_INCOMPLETE');
+    expect(errors(issues).length).toBeGreaterThan(0);
+  });
+
+  it('blocks generic style language with no signature device', () => {
+    const issues = designContractIssues({
+      ...FULL,
+      aesthetic: { subject_world: 'sleek modern tech', one_job: 'look premium', aesthetic_risk: 'none really', anti_template_check: 'nothing rejected' },
+    }, null);
+    expect(codes(issues)).toContain('GENERIC_AESTHETIC_THESIS');
+  });
+
+  it('accepts the legacy anti_template spelling as the check', () => {
+    const { anti_template_check, ...aesthetic } = FULL.aesthetic;
+    const issues = designContractIssues({ ...FULL, aesthetic: { ...aesthetic, anti_template: 'rejected a centered title card' } }, null);
+    expect(codes(issues)).not.toContain('AESTHETIC_THESIS_INCOMPLETE');
+  });
+
+  it('blocks a partially-filled visual direction', () => {
+    const issues = designContractIssues({ ...FULL, visual_direction: { visual_tradition: 'Swiss Pulse precision grid' } }, null);
+    expect(codes(issues)).toContain('VISUAL_DIRECTION_INCOMPLETE');
+  });
+
+  it('does not report placeholder-length values as real decisions', () => {
+    const issues = designContractIssues({ ...FULL, motion_budget: 'x' }, null);
+    expect(codes(issues)).toContain('DESIGN_CONTRACT_BUDGET_INCOMPLETE');
+  });
+
+  it('blocks scenes with no depth layers or motion verbs, naming them', () => {
+    const issues = designContractIssues({ ...FULL, scenes: [{ id: 'intro' }, { id: 'outro' }] }, null);
+    expect(codes(issues)).toEqual(expect.arrayContaining(['SCENE_DEPTH_LAYERS_MISSING', 'SCENE_MOTION_VERBS_MISSING']));
+    expect(JSON.stringify(issues)).toContain('intro');
+  });
+
+  it('falls back to the scene map when the contract does not restate scenes', () => {
+    const { scenes, ...noScenes } = FULL;
+    const issues = designContractIssues(noScenes, { scenes: [{ id: 'from-map' }] });
+    expect(codes(issues)).toContain('SCENE_DEPTH_LAYERS_MISSING');
+    expect(JSON.stringify(issues)).toContain('from-map');
+  });
+
+  it('accepts motion_choreography as the motion-verb decision', () => {
+    const issues = designContractIssues({ ...FULL, scenes: [{ id: 's1', depth_layers: 'BG/MG/FG', motion_choreography: 'the trace draws in' }] }, null);
+    expect(codes(issues)).not.toContain('SCENE_MOTION_VERBS_MISSING');
+  });
+});

--- a/packages/tools/test/render-draft.test.ts
+++ b/packages/tools/test/render-draft.test.ts
@@ -20,11 +20,37 @@ function writeHtml(dir: string, body: string, attrs = 'data-composition-id="main
   writeFileSync(join(dir, 'index.html'), `<!doctype html><html><body><div id="root" ${attrs}>${body}</div></body></html>`, 'utf8');
 }
 
+/** A contract that satisfies the design budget, so these tests exercise the gate
+ *  they name rather than tripping the design preflight. */
+const CONTRACT_BUDGET = {
+  aesthetic: {
+    subject_world: 'battery lab oscilloscope traces',
+    one_job: 'show the charge curve flattening',
+    signature_device: 'the trace becomes the progress line',
+    aesthetic_risk: 'no product shot until the payoff',
+    anti_template_check: 'rejected a centered title card for an edge-anchored trace',
+  },
+  visual_direction: {
+    visual_tradition: 'Swiss Pulse precision grid',
+    lazy_defaults_rejected: 'rejected neon circles; using instrument traces',
+    video_scale: '1920x1080: headline 88-132px, body 44-56px',
+    depth_layer_rule: 'BG grid, MG trace, FG metadata ticks',
+    motion_verb_rule: 'the trace draws, the value counts up',
+    rhythm_pattern: 'hook-build-HOLD-resolve',
+  },
+  layout_boxes: { focal: 'left two thirds', supporting: 'right column' },
+  typography_tokens: { title: '96px', body: '44px', label: '40px' },
+  color_tokens: { bg: '#081018', ink: '#f3f0e8', accent: '#ffb000' },
+  motion_budget: 'the trace draws once; everything else holds still',
+  scene_variation: 'no two adjacent scenes share a layout grammar',
+};
+
 function writeContract(dir: string, extra: Record<string, unknown> = {}): void {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, 'design-contract.json'), JSON.stringify({
     canvas: { width: 1920, height: 1080, duration: 10 },
-    scenes: [{ id: 's1', start: 0, duration: 10, headline: 'Launch' }],
+    scenes: [{ id: 's1', start: 0, duration: 10, headline: 'Launch', depth_layers: 'BG grid / MG trace / FG ticks', motion_verbs: 'trace draws' }],
+    ...CONTRACT_BUDGET,
     ...extra,
   }, null, 2), 'utf8');
 }
@@ -37,6 +63,44 @@ function writeSceneMap(dir: string, extra: Record<string, unknown> = {}): void {
     ...extra,
   }, null, 2), 'utf8');
 }
+
+describe('design contract preflight', () => {
+  it('blocks a draft when the declared contract has no design budget', async () => {
+    const p = tmpProject('thin-contract');
+    try {
+      writeHtml(p.composition, '<div>Launch</div>');
+      mkdirSync(p.composition, { recursive: true });
+      // A contract that is a canvas + scenes, with none of the budget.
+      writeFileSync(join(p.composition, 'design-contract.json'), JSON.stringify({
+        canvas: { width: 1920, height: 1080, duration: 10 },
+        scenes: [{ id: 's1', start: 0, duration: 10, headline: 'Launch' }],
+      }), 'utf8');
+
+      const res = await draft({ project: p.composition, output: p.output, reportPath: p.report });
+
+      expect(res).toMatchObject({ ok: false, errorCode: 'E_DESIGN_CONTRACT_BLOCKED' });
+      expect(JSON.stringify(res.report)).toContain('DESIGN_CONTRACT_BUDGET_INCOMPLETE');
+      expect(existsSync(p.output)).toBe(false);
+    } finally {
+      rmSync(p.root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not second-guess a composition that ships no contract', async () => {
+    const p = tmpProject('no-contract');
+    try {
+      // No design-contract.json at all: the gate must have no opinion, so this
+      // gets past the design step and fails later for a real reason.
+      writeHtml(p.composition, '<script src="https://cdn.example.com/runtime.js"></script><div>Launch</div>');
+
+      const res = await draft({ project: p.composition, output: p.output, reportPath: p.report });
+
+      expect(res.errorCode).not.toBe('E_DESIGN_CONTRACT_BLOCKED');
+    } finally {
+      rmSync(p.root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('composition draft gate', () => {
   it('blocks remote runtime resources before rendering', async () => {


### PR DESCRIPTION
> **Stacked on #7** (→ #6 → #5 → #4 → #3). Merge in order; GitHub retargets automatically.

## Why

The design contract is documented as the composition's *budget*, but nothing checked it. A contract naming a canvas and some scenes — no thesis, no visual direction, no motion budget — sailed straight through to a preview and a full mp4 render. The design problems then surfaced only after the expensive part, which is exactly backwards: repairing a contract is cheap.

This is the clause deferred from #4. It could not land there because it needs a gate to be true about: `composition-qa.ts` had zero `art_direction` / `aesthetic` / `visual_direction` awareness, so the prompt alone would have described a gate that did not exist.

## What

**The check** — `designContractIssues(contract, sceneMap)`, pure:

| Finding | Severity |
|---|---|
| `DESIGN_CONTRACT_BUDGET_INCOMPLETE` | **error** when a *preview-required* section is missing (`aesthetic`, `visual_direction`, `motion_budget`, `scene_variation`); warning otherwise |
| `AESTHETIC_THESIS_INCOMPLETE` — thesis present but hollow | error |
| `GENERIC_AESTHETIC_THESIS` — "sleek premium modern tech" with no signature device | error |
| `VISUAL_DIRECTION_INCOMPLETE` — partial VisualDirectionV1 | error |
| `SCENE_DEPTH_LAYERS_MISSING` / `SCENE_MOTION_VERBS_MISSING` | error |

**The wiring** — deliberately not uniform:

- `ovs snapshot` **blocks** — no preview off a thin contract.
- `ovs lint` / `ovs inspect` **report** — that is how the agent learns what to repair.
- `ovs draft` **blocks** with `E_DESIGN_CONTRACT_BLOCKED` before it spends a render.
- `ovs render` is **left structural-only.** It is the raw renderer; blocking a work-in-progress render on a design budget would be hostile, and the rule's own words are "before preview or draft". Upstream's preflight is uniform here, but upstream also removed raw render from the agent surface — this repo keeps it as a user-facing command.
- **No `design-contract.json` → no opinion.** Raw HyperFrames projects and plain renders are untouched. This is the safety valve that makes the gate safe to turn on.

Only now that the gate exists do `frontend-design` and `stage-compose` claim it.

## A note on the fixtures

The existing draft fixtures declared a canvas and scenes with *no budget* — so with this change one of them stopped testing what it names ("blocks contract/html canvas mismatches") and started tripping the design gate instead. That is the feature working. The shared `writeContract` helper now carries a real budget, so each test exercises its own gate again, and a thin contract gets its own regression.

## Verification

- `pnpm build` + `typecheck` green. `pnpm test` **153 passed / 8 skipped** (+14: 12 unit + 2 draft-path).
- Fixtures cover complete / thin / hollow / generic / legacy-`anti_template` alias / partial-VisualDirection / placeholder-length values / scene-map fallback / `motion_choreography` alias, plus "no contract → no findings".
- Every code named in the skills was grepped back to `packages/tools/src` before it was written down.