### PR TITLE
Conform concat inputs, pin stereo layouts, cover CJK captions, guard opaque overlays

### DIFF
--- a/packages/tools/src/edit/args.ts
+++ b/packages/tools/src/edit/args.ts
@@ -52,15 +52,127 @@ export function buildTrimArgs(p: TrimParams): string[] {
 }
 
 /** Concat via the demuxer + a list file (built by the executor). Inputs should
- *  share stream layout (e.g. trims of the same source); we re-encode for safety. */
+ *  share stream layout (e.g. trims of the same source); we re-encode for safety.
+ *  Re-encoding does NOT fix a mixed set: the demuxer takes its canvas and time
+ *  base from the FIRST input and reinterprets the rest against it, so the
+ *  executor conforms mismatched inputs first (see `chooseConcatTarget`). */
 export function buildConcatArgs(listFile: string, output: string): string[] {
   return ['-y', '-f', 'concat', '-safe', '0', '-i', listFile, ...VIDEO_ENCODE, ...AUDIO_ENCODE, ...FASTSTART, output];
 }
 
-export function buildBurnsubsArgs(input: string, srtPath: string, output: string): string[] {
+/** Width/height/frame-rate of one concat input's video stream. */
+export interface ConcatInputSpec {
+  width: number;
+  height: number;
+  fps: number;
+}
+
+/**
+ * Decide the shared canvas + frame rate a concat set must be conformed onto.
+ * Returns null when nothing needs conforming: the set is already uniform, or
+ * any input's spec is unknown (a guard that cannot see must not rewrite a
+ * legitimate join). The target is the largest canvas (rounded up to even, as
+ * libx264 requires) at the highest rate — conforming upgrades a part and never
+ * crops a designed frame.
+ */
+export function chooseConcatTarget(specs: Array<ConcatInputSpec | null>): ConcatInputSpec | null {
+  if (!specs.length || specs.some((s) => s === null)) return null;
+  const known = specs as ConcatInputSpec[];
+  const first = known[0];
+  const uniform = known.every((s) => s.width === first.width && s.height === first.height && s.fps === first.fps);
+  if (uniform) return null;
+  const even = (n: number) => n + (n % 2);
+  return {
+    width: even(Math.max(...known.map((s) => s.width))),
+    height: even(Math.max(...known.map((s) => s.height))),
+    fps: Math.max(...known.map((s) => s.fps)),
+  };
+}
+
+/** Re-encode one input onto the shared canvas and frame rate, letterboxing
+ *  rather than cropping so a designed frame keeps every pixel it composed. */
+export function buildConformArgs(input: string, target: ConcatInputSpec, output: string): string[] {
+  const filter = [
+    `scale=${target.width}:${target.height}:force_original_aspect_ratio=decrease`,
+    `pad=${target.width}:${target.height}:(ow-iw)/2:(oh-ih)/2`,
+    'setsar=1',
+    `fps=${target.fps}`,
+  ].join(',');
+  return ['-y', '-i', input, '-vf', filter, ...VIDEO_ENCODE, '-c:a', 'copy', ...FASTSTART, output];
+}
+
+/**
+ * Message for a joined output whose duration does not match its parts, or null
+ * when the join is sound (or either duration is unknown — fail open). A joined
+ * timeline that does not match the material it was built from is corrupt
+ * however it happened; saying so here costs one probe instead of a repair loop
+ * discovered at the draft.
+ */
+export function concatDurationDriftError(expectedSec: number | null, actualSec: number): string | null {
+  if (!expectedSec || !finiteNum(expectedSec) || expectedSec <= 0 || !finiteNum(actualSec) || actualSec <= 0) return null;
+  const driftSec = Math.abs(actualSec - expectedSec);
+  if (driftSec <= Math.max(0.5, expectedSec * 0.02)) return null;
+  return (
+    `concat produced a ${actualSec.toFixed(2)}s video from parts totalling ${expectedSec.toFixed(2)}s`
+    + ` (off by ${driftSec.toFixed(2)}s). The output was written but does not match its material, so anything`
+    + ` timed against the plan — narration, captions — will drift. Re-check the parts before using it.`
+  );
+}
+
+/** Caption font family for `burnsubs`, chosen by the caption text's script.
+ *
+ * Left unset, libass resolves a default family per platform — on macOS that is
+ * a Japanese-coverage font, which renders Simplified-only characters as tofu
+ * boxes while shared-with-Japanese characters look fine, so nothing fails and
+ * the video ships. libass does not fall back across families, so the ONE
+ * family named here must cover the deliverable script. Kana wins over Han
+ * because Japanese text contains both. Latin-only captions keep the platform
+ * default. */
+export function captionFontForText(text: string, platform: NodeJS.Platform): string {
+  const hasKana = /[\u3040-\u30ff]/u.test(text);
+  const hasHan = /[\u4e00-\u9fff]/u.test(text);
+  if (hasKana) {
+    if (platform === 'darwin') return 'Hiragino Sans';
+    if (platform === 'win32') return 'Yu Gothic UI';
+    return 'Noto Sans CJK JP';
+  }
+  if (hasHan) {
+    if (platform === 'darwin') return 'PingFang SC';
+    if (platform === 'win32') return 'Microsoft YaHei';
+    return 'Noto Sans CJK SC';
+  }
+  return '';
+}
+
+export function buildBurnsubsArgs(input: string, srtPath: string, output: string, fontName?: string): string[] {
   // The subtitles filter takes a path; escape backslashes, colons and single quotes.
   const escaped = srtPath.replace(/\\/g, '\\\\').replace(/:/g, '\\:').replace(/'/g, "\\'");
-  return ['-y', '-i', input, '-vf', `subtitles='${escaped}'`, ...VIDEO_ENCODE, '-c:a', 'copy', ...FASTSTART, output];
+  const style = fontName ? `:force_style='FontName=${fontName}'` : '';
+  return ['-y', '-i', input, '-vf', `subtitles='${escaped}'${style}`, ...VIDEO_ENCODE, '-c:a', 'copy', ...FASTSTART, output];
+}
+
+/** Pixel formats that can carry transparency — the only overlays that can sit
+ *  on a full frame without erasing it. */
+const ALPHA_PIX_FMT_RE = /(yuva|argb|abgr|rgba|bgra|ya8|ya16|gbrap)/i;
+
+export function pixFmtHasAlpha(pixFmt: string | null | undefined): boolean {
+  return ALPHA_PIX_FMT_RE.test(String(pixFmt ?? ''));
+}
+
+/** Would `overlay` erase the base instead of compositing over it?
+ *
+ * True exactly when the overlay covers the whole base frame and its pixel
+ * format carries no alpha — an opaque full-frame layer replaces every pixel.
+ * Fail-open on missing probe data: a guard that cannot see must not block a
+ * legitimate edit. Sub-frame opaque overlays (logo boxes, lower thirds) keep
+ * working: they cover only the region they occupy, which is the intent. */
+export function overlayWouldEraseBase(
+  base: { width: number; height: number } | null,
+  overlay: { width: number; height: number; hasAlpha: boolean } | null,
+): boolean {
+  if (!base || !overlay) return false;
+  if (!(base.width > 0 && base.height > 0 && overlay.width > 0 && overlay.height > 0)) return false;
+  return overlay.width >= base.width && overlay.height >= base.height && !overlay.hasAlpha;
 }
 
 export function buildOverlayArgs(base: string, overlay: string, x: number, y: number, output: string): string[] {
@@ -78,12 +190,22 @@ export function buildLoudnessArgs(input: string): string[] {
   return ['-i', input, '-af', `loudnorm=I=${LOUDNORM.I}:TP=${LOUDNORM.TP}:LRA=${LOUDNORM.LRA}:print_format=json`, '-f', 'null', '-'];
 }
 
+/** The publish-loudness audio chain. The trailing aformat pins a KNOWN stereo
+ *  layout: a mono input (every TTS-only mix is mono) otherwise dies in layout
+ *  negotiation between aresample and the aac encoder — "Cannot select channel
+ *  layout for the link between Parsed_aresample_1 and format_out_0_1". Stereo
+ *  is the delivery standard and a mono→stereo upmix is lossless channel
+ *  duplication. */
+export function normalizeLoudnessAudioFilter(): string {
+  return `loudnorm=I=${LOUDNORM.I}:TP=${LOUDNORM.TP}:LRA=${LOUDNORM.LRA},aresample=${MIX_OUTPUT_SR},aformat=channel_layouts=stereo`;
+}
+
 export function buildNormalizeLoudnessArgs(input: string, output: string): string[] {
   return [
     '-y', '-i', input,
     '-map', '0:v?', '-map', '0:a:0',
     '-c:v', 'copy',
-    '-filter:a:0', `loudnorm=I=${LOUDNORM.I}:TP=${LOUDNORM.TP}:LRA=${LOUDNORM.LRA},aresample=${MIX_OUTPUT_SR}`,
+    '-filter:a:0', normalizeLoudnessAudioFilter(),
     '-c:a', 'aac', '-ar', String(MIX_OUTPUT_SR),
     ...FASTSTART,
     output,
@@ -134,7 +256,9 @@ export function buildMixFilter(plan: MixPlan): { filter: string; maps: string[] 
 
   const amixInputs = labels.length;
   parts.push(`${labels.join('')}amix=inputs=${amixInputs}:normalize=0[amixed]`);
-  parts.push(`[amixed]loudnorm=I=${LOUDNORM.I}:TP=${LOUDNORM.TP}:LRA=${LOUDNORM.LRA}[outa]`);
+  // loudnorm upsamples to 192 kHz internally, so resample back before the
+  // encoder; the trailing aformat pins stereo — see normalizeLoudnessAudioFilter.
+  parts.push(`[amixed]loudnorm=I=${LOUDNORM.I}:TP=${LOUDNORM.TP}:LRA=${LOUDNORM.LRA},aresample=${MIX_OUTPUT_SR},aformat=channel_layouts=stereo[outa]`);
 
   return { filter: parts.join(';'), maps: ['-map', '0:v', '-map', '[outa]'] };
 }

--- a/packages/tools/src/edit/edit.ts
+++ b/packages/tools/src/edit/edit.ts
@@ -26,13 +26,20 @@ import {
   buildProbeArgs,
   buildTrimArgs,
   buildConcatArgs,
+  buildConformArgs,
   buildBurnsubsArgs,
   buildOverlayArgs,
   buildExtractFrameArgs,
   buildLoudnessArgs,
   buildNormalizeLoudnessArgs,
   buildMixArgs,
+  captionFontForText,
+  chooseConcatTarget,
+  concatDurationDriftError,
   finiteNum,
+  overlayWouldEraseBase,
+  pixFmtHasAlpha,
+  type ConcatInputSpec,
   type TrimParams,
   type AudioSegment,
   type OnExistingAudio,
@@ -83,6 +90,7 @@ export interface ProbeResult {
   width: number;
   height: number;
   fps: number;
+  pix_fmt: string | null;
   has_audio: boolean;
   v_codec: string | null;
   a_codec: string | null;
@@ -116,6 +124,7 @@ export async function probeMedia(input: string): Promise<ProbeResult> {
     width: Number(v?.width ?? 0) || 0,
     height: Number(v?.height ?? 0) || 0,
     fps: parseRate(v?.avg_frame_rate ?? v?.r_frame_rate),
+    pix_fmt: typeof v?.pix_fmt === 'string' ? v.pix_fmt : null,
     has_audio: Boolean(a),
     v_codec: (v?.codec_name as string) ?? null,
     a_codec: (a?.codec_name as string) ?? null,
@@ -161,18 +170,32 @@ export interface NormalizeLoudnessResult extends OutputResult {
   loudness: LoudnessResult;
 }
 
-async function ffmpeg(args: string[], spec?: FfmpegProgressSpec): Promise<void> {
+async function ffmpeg(args: string[], spec?: FfmpegProgressSpec, outputOnFailure?: string): Promise<void> {
   const { ffmpeg: bin } = resolveFfmpegTools();
-  if (!spec?.onProgress) {
-    await runOk(bin, args, spec?.signal ? { signal: spec.signal } : {});
-    return;
-  }
-  // Progress path: use `run` (via runFfmpeg) so we can stream, then reproduce
-  // runOk's throw-on-failure contract with the same message shape.
-  const r = await runFfmpeg(bin, args, spec);
-  if (r.code !== 0) {
-    const tail = r.stderr.trim().split('\n').slice(-12).join('\n');
-    throw new Error(`'${bin}' exited with code ${r.code}\n${tail}`);
+  try {
+    if (!spec?.onProgress) {
+      await runOk(bin, args, spec?.signal ? { signal: spec.signal } : {});
+      return;
+    }
+    // Progress path: use `run` (via runFfmpeg) so we can stream, then reproduce
+    // runOk's throw-on-failure contract with the same message shape.
+    const r = await runFfmpeg(bin, args, spec);
+    if (r.code !== 0) {
+      const tail = r.stderr.trim().split('\n').slice(-12).join('\n');
+      throw new Error(`'${bin}' exited with code ${r.code}\n${tail}`);
+    }
+  } catch (e) {
+    // ffmpeg creates its output before the filter graph initializes, so a
+    // failed run must not leave the partial file behind: a caller that stats
+    // the path after a caught error sees a plausible, unusable delivery.
+    if (outputOnFailure) {
+      try {
+        rmSync(resolve(outputOnFailure), { force: true });
+      } catch {
+        /* absent or busy — best effort */
+      }
+    }
+    throw e;
   }
 }
 
@@ -231,54 +254,162 @@ export async function trim(params: TrimParams, opts?: EditRunOptions): Promise<O
   const inputDurationSec = (await probeMedia(params.input)).duration;
   const rangeError = validateTrimRequest(inputDurationSec, params.start_sec, effectiveDur);
   if (rangeError) throw new Error(rangeError);
-  await ffmpeg(args, progressSpec('trim', 'edit', effectiveDur, opts));
+  await ffmpeg(args, progressSpec('trim', 'edit', effectiveDur, opts), params.output);
   const outputError = await validateTrimOutput(params.output);
   if (outputError) throw new Error(outputError);
   return { output: resolve(params.output) };
 }
 
-/** Total duration across the concat inputs, or null if any can't be probed
- *  (percent then falls back to heartbeat-only). Only worth the ffprobe fan-out
- *  when a progress consumer is listening. */
-async function concatDurationSec(inputs: string[]): Promise<number | null> {
-  const durs = await mapWithConcurrencyLimit(inputs, PROBE_CONCURRENCY, (p) => safeDuration(p));
-  return durs.every((d): d is number => typeof d === 'number' && d > 0)
-    ? durs.reduce((a, b) => a + b, 0)
-    : null;
+/** One input's probe, degraded to nulls when the probe fails: concat's conform
+ *  and drift checks must fail open, never fail the join over a probe miss. */
+async function safeConcatProbe(input: string): Promise<{ durationSec: number | null; spec: ConcatInputSpec | null }> {
+  try {
+    const p = await probeMedia(input);
+    return {
+      durationSec: p.duration > 0 ? p.duration : null,
+      spec: p.width > 0 && p.height > 0 && p.fps > 0 ? { width: p.width, height: p.height, fps: p.fps } : null,
+    };
+  } catch {
+    return { durationSec: null, spec: null };
+  }
 }
 
-export async function concat(inputs: string[], output: string, opts?: EditRunOptions): Promise<OutputResult> {
+/** What a join had to change about its inputs before they could be joined. */
+export interface ConcatConformReport {
+  applied: true;
+  target: string;
+  conformed_inputs: Array<{ input: string; from: string; to: string }>;
+  note: string;
+}
+
+export interface ConcatResult extends OutputResult {
+  conform?: ConcatConformReport;
+}
+
+const specLabel = (s: ConcatInputSpec): string => `${s.width}x${s.height}@${s.fps}`;
+
+export async function concat(inputs: string[], output: string, opts?: EditRunOptions): Promise<ConcatResult> {
   if (inputs.length < 1) throw new Error('concat: at least one input is required');
   ensureParentDir(output);
   const list = join(tmpdir(), `ovs-concat-${randomUUID()}.txt`);
-  const body = inputs.map((p) => `file '${resolve(p).replace(/'/g, "'\\''")}'`).join('\n');
-  writeFileSync(list, body + '\n', 'utf8');
+  const scratch: string[] = [];
   try {
-    const durationSec = wantsProgress(opts) ? await concatDurationSec(inputs) : null;
-    await ffmpeg(buildConcatArgs(list, output), progressSpec('concat', 'edit', durationSec, opts));
+    const probes = await mapWithConcurrencyLimit(inputs, PROBE_CONCURRENCY, (p) => safeConcatProbe(p));
+    const durations = probes.map((p) => p.durationSec);
+    const expectedSec = durations.every((d): d is number => typeof d === 'number' && d > 0)
+      ? durations.reduce((a, b) => a + b, 0)
+      : null;
+
+    // The concat demuxer takes its canvas and time base from the FIRST input
+    // and reinterprets the rest against it, so joining a mixed set silently
+    // corrupts the timeline (e.g. 15fps parts after a 24fps first input come
+    // out 24/15 longer) — conform mismatched inputs onto the largest canvas at
+    // the highest rate before joining.
+    const target = chooseConcatTarget(probes.map((p) => p.spec));
+    let joinInputs = inputs;
+    let conform: ConcatConformReport | undefined;
+    if (target) {
+      const conformedInputs: ConcatConformReport['conformed_inputs'] = [];
+      joinInputs = [];
+      for (let i = 0; i < inputs.length; i += 1) {
+        const spec = probes[i].spec as ConcatInputSpec;
+        if (spec.width === target.width && spec.height === target.height && spec.fps === target.fps) {
+          joinInputs.push(inputs[i]);
+          continue;
+        }
+        const conformed = join(tmpdir(), `ovs-conform-${randomUUID()}.mp4`);
+        scratch.push(conformed);
+        // No progress spec: streaming each conform as its own 0-100% cycle
+        // would make one concat report several restarting bars. Keep the abort
+        // signal so a cancelled concat stops mid-conform.
+        await ffmpeg(
+          buildConformArgs(inputs[i], target, conformed),
+          opts?.signal ? { op: 'concat', phase: 'edit', durationSec: null, signal: opts.signal } : undefined,
+          conformed,
+        );
+        conformedInputs.push({ input: inputs[i], from: specLabel(spec), to: specLabel(target) });
+        joinInputs.push(conformed);
+      }
+      // Re-encoding the caller's material to a canvas and frame rate it did not
+      // ask for is a change to the delivery, not an implementation detail —
+      // report it so the caller can weigh re-rendering the parts instead.
+      conform = {
+        applied: true,
+        target: specLabel(target),
+        conformed_inputs: conformedInputs,
+        note: 'Inputs did not share one canvas and frame rate, so the mismatched ones were re-encoded onto the'
+          + ' largest canvas at the highest rate before joining. An upscaled part carries the detail of its'
+          + ' original render, not of the target — re-render it at delivery quality if that matters.',
+      };
+    }
+
+    const body = joinInputs.map((p) => `file '${resolve(p).replace(/'/g, "'\\''")}'`).join('\n');
+    writeFileSync(list, body + '\n', 'utf8');
+    await ffmpeg(buildConcatArgs(list, output), progressSpec('concat', 'edit', expectedSec, opts), output);
+
+    const actualSec = (await safeDuration(output)) ?? 0;
+    const driftError = concatDurationDriftError(expectedSec, actualSec);
+    if (driftError) throw new Error(driftError);
+
+    return { output: resolve(output), ...(conform ? { conform } : {}) };
   } finally {
     rmSync(list, { force: true });
+    for (const tmp of scratch) rmSync(tmp, { force: true });
   }
-  return { output: resolve(output) };
 }
 
 export async function burnsubs(input: string, srtPath: string, output: string, opts?: EditRunOptions): Promise<OutputResult> {
   ensureParentDir(output);
+  // Pick a caption font that covers the subtitle text's script; the platform
+  // default family can render Simplified-only characters as tofu boxes.
+  let subtitleText = '';
+  try {
+    subtitleText = readFileSync(resolve(srtPath), 'utf8');
+  } catch {
+    /* unreadable subtitles fail in ffmpeg with its own message */
+  }
+  const fontName = captionFontForText(subtitleText, process.platform);
   const durationSec = wantsProgress(opts) ? await safeDuration(input) : null;
-  await ffmpeg(buildBurnsubsArgs(input, resolve(srtPath), output), progressSpec('burnsubs', 'edit', durationSec, opts));
+  await ffmpeg(buildBurnsubsArgs(input, resolve(srtPath), output, fontName || undefined), progressSpec('burnsubs', 'edit', durationSec, opts), output);
   return { output: resolve(output) };
 }
 
 export async function overlay(base: string, ov: string, x: number, y: number, output: string, opts?: EditRunOptions): Promise<OutputResult> {
   ensureParentDir(output);
-  const durationSec = wantsProgress(opts) ? await safeDuration(base) : null;
-  await ffmpeg(buildOverlayArgs(base, ov, x, y, output), progressSpec('overlay', 'edit', durationSec, opts));
+  const probeOrNull = async (p: string): Promise<ProbeResult | null> => {
+    try {
+      return await probeMedia(p);
+    } catch {
+      return null;
+    }
+  };
+  const [baseInfo, overlayInfo] = await Promise.all([probeOrNull(base), probeOrNull(ov)]);
+  // A full-frame overlay with no alpha channel does not composite — it
+  // REPLACES every pixel of the base footage. Fail closed with the real
+  // options instead of shipping the loss; sub-frame opaque overlays (logo
+  // boxes, lower thirds) keep working.
+  if (
+    overlayWouldEraseBase(
+      baseInfo,
+      overlayInfo ? { width: overlayInfo.width, height: overlayInfo.height, hasAlpha: pixFmtHasAlpha(overlayInfo.pix_fmt) } : null,
+    )
+  ) {
+    throw new Error(
+      `overlay covers the full ${baseInfo?.width}x${baseInfo?.height} base with an opaque `
+      + `${overlayInfo?.width}x${overlayInfo?.height} layer (pix_fmt ${overlayInfo?.pix_fmt || 'unknown'} has no alpha), `
+      + 'which would completely replace the base footage instead of compositing over it. Use edge elements smaller '
+      + 'than the frame (logo box, lower third), or plan this beat as a composed primary segment without footage '
+      + 'underneath; a full-frame brand layer over footage needs an alpha-capable overlay (e.g. a transparent PNG/WebM).',
+    );
+  }
+  const durationSec = baseInfo && baseInfo.duration > 0 ? baseInfo.duration : null;
+  await ffmpeg(buildOverlayArgs(base, ov, x, y, output), progressSpec('overlay', 'edit', durationSec, opts), output);
   return { output: resolve(output) };
 }
 
 export async function extractFrame(input: string, atSec: number, output: string): Promise<OutputResult> {
   ensureParentDir(output);
-  await ffmpeg(buildExtractFrameArgs(input, atSec, output));
+  await ffmpeg(buildExtractFrameArgs(input, atSec, output), undefined, output);
   return { output: resolve(output) };
 }
 
@@ -314,7 +445,7 @@ export async function normalizeLoudness(input: string, output: string, opts?: Ed
   ensureParentDir(output);
   const probe = await probeMedia(input);
   if (!probe.has_audio) throw new Error('normalize-loudness: input has no audio stream');
-  await ffmpeg(buildNormalizeLoudnessArgs(input, output), progressSpec('normalize_loudness', 'edit', probe.duration, opts));
+  await ffmpeg(buildNormalizeLoudnessArgs(input, output), progressSpec('normalize_loudness', 'edit', probe.duration, opts), output);
   return { output: resolve(output), loudness: await loudness(output, opts) };
 }
 
@@ -460,7 +591,7 @@ export async function mix(params: MixParams, opts?: EditRunOptions): Promise<Mix
     on_existing_audio: params.on_existing_audio ?? 'reject',
     output: params.output,
   });
-  await ffmpeg(args, progressSpec('mix', 'edit', probe.duration, opts));
+  await ffmpeg(args, progressSpec('mix', 'edit', probe.duration, opts), params.output);
   return { output: resolve(params.output), coverage: await coverageForSegments(probe.duration, params.segments, opts) };
 }
 
@@ -476,7 +607,7 @@ async function runJumpCut(input: string, kept: Span[], output: string, spec?: Ff
     '-y', '-i', input, '-filter_complex', filter, ...maps,
     '-c:v', 'libx264', '-preset', 'veryfast', '-crf', '18', '-pix_fmt', 'yuv420p',
     '-c:a', 'aac', '-ar', '48000', '-movflags', '+faststart', output,
-  ], spec);
+  ], spec, output);
 }
 
 export interface TrimSilenceParams {

--- a/packages/tools/test/edit-ops-correctness.test.ts
+++ b/packages/tools/test/edit-ops-correctness.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildBurnsubsArgs,
+  buildConformArgs,
+  buildMixFilter,
+  buildNormalizeLoudnessArgs,
+  captionFontForText,
+  chooseConcatTarget,
+  concatDurationDriftError,
+  overlayWouldEraseBase,
+  pixFmtHasAlpha,
+} from '../src/edit/args';
+
+describe('captionFontForText', () => {
+  it('names a Simplified-coverage family for Han-only text per platform', () => {
+    expect(captionFontForText('指挥官与协作', 'darwin')).toBe('PingFang SC');
+    expect(captionFontForText('指挥官与协作', 'win32')).toBe('Microsoft YaHei');
+    expect(captionFontForText('指挥官与协作', 'linux')).toBe('Noto Sans CJK SC');
+  });
+
+  it('lets kana win over Han because Japanese text contains both', () => {
+    expect(captionFontForText('東京へようこそ', 'darwin')).toBe('Hiragino Sans');
+    expect(captionFontForText('東京へようこそ', 'win32')).toBe('Yu Gothic UI');
+    expect(captionFontForText('東京へようこそ', 'linux')).toBe('Noto Sans CJK JP');
+  });
+
+  it('keeps the platform default for Latin-only captions', () => {
+    expect(captionFontForText('1\n00:00:00,000 --> 00:00:01,000\nHello world', 'darwin')).toBe('');
+  });
+});
+
+describe('burnsubs font style', () => {
+  it('appends force_style only when a font is chosen', () => {
+    const plain = buildBurnsubsArgs('in.mp4', 'subs.srt', 'out.mp4');
+    expect(plain.join(' ')).not.toContain('force_style');
+    const styled = buildBurnsubsArgs('in.mp4', 'subs.srt', 'out.mp4', 'PingFang SC');
+    const vf = styled[styled.indexOf('-vf') + 1] ?? '';
+    expect(vf).toContain("force_style='FontName=PingFang SC'");
+  });
+});
+
+describe('overlayWouldEraseBase', () => {
+  const base = { width: 1920, height: 1080 };
+  it('flags an opaque overlay covering the whole base', () => {
+    expect(overlayWouldEraseBase(base, { width: 1920, height: 1080, hasAlpha: false })).toBe(true);
+    expect(overlayWouldEraseBase(base, { width: 2560, height: 1440, hasAlpha: false })).toBe(true);
+  });
+  it('allows alpha-capable and sub-frame overlays', () => {
+    expect(overlayWouldEraseBase(base, { width: 1920, height: 1080, hasAlpha: true })).toBe(false);
+    expect(overlayWouldEraseBase(base, { width: 480, height: 120, hasAlpha: false })).toBe(false);
+  });
+  it('fails open on missing or degenerate probe data', () => {
+    expect(overlayWouldEraseBase(null, { width: 1920, height: 1080, hasAlpha: false })).toBe(false);
+    expect(overlayWouldEraseBase(base, null)).toBe(false);
+    expect(overlayWouldEraseBase({ width: 0, height: 0 }, { width: 1920, height: 1080, hasAlpha: false })).toBe(false);
+  });
+});
+
+describe('pixFmtHasAlpha', () => {
+  it('recognizes alpha-capable pixel formats', () => {
+    expect(pixFmtHasAlpha('yuva420p')).toBe(true);
+    expect(pixFmtHasAlpha('rgba')).toBe(true);
+    expect(pixFmtHasAlpha('gbrap10le')).toBe(true);
+  });
+  it('rejects opaque formats and missing data', () => {
+    expect(pixFmtHasAlpha('yuv420p')).toBe(false);
+    expect(pixFmtHasAlpha(null)).toBe(false);
+    expect(pixFmtHasAlpha(undefined)).toBe(false);
+  });
+});
+
+describe('chooseConcatTarget', () => {
+  it('returns null for a uniform set (nothing to conform)', () => {
+    const s = { width: 1920, height: 1080, fps: 24 };
+    expect(chooseConcatTarget([s, { ...s }])).toBeNull();
+  });
+
+  it('fails open when any input spec is unknown', () => {
+    expect(chooseConcatTarget([{ width: 1920, height: 1080, fps: 24 }, null])).toBeNull();
+    expect(chooseConcatTarget([])).toBeNull();
+  });
+
+  it('targets the largest canvas at the highest rate, rounded up to even', () => {
+    const target = chooseConcatTarget([
+      { width: 1918, height: 1080, fps: 24 },
+      { width: 1920, height: 1080, fps: 15 },
+      { width: 1280, height: 720, fps: 15 },
+    ]);
+    expect(target).toEqual({ width: 1920, height: 1080, fps: 24 });
+  });
+
+  it('rounds an odd max dimension up to the next even value', () => {
+    const target = chooseConcatTarget([
+      { width: 1919, height: 1079, fps: 30 },
+      { width: 640, height: 480, fps: 30 },
+    ]);
+    expect(target).toEqual({ width: 1920, height: 1080, fps: 30 });
+  });
+});
+
+describe('buildConformArgs', () => {
+  it('letterboxes onto the target canvas and resamples the frame rate', () => {
+    const a = buildConformArgs('in.mp4', { width: 1920, height: 1080, fps: 24 }, 'out.mp4');
+    const vf = a[a.indexOf('-vf') + 1] ?? '';
+    expect(vf).toContain('scale=1920:1080:force_original_aspect_ratio=decrease');
+    expect(vf).toContain('pad=1920:1080:(ow-iw)/2:(oh-ih)/2');
+    expect(vf).toContain('setsar=1');
+    expect(vf).toContain('fps=24');
+    expect(a).toContain('out.mp4');
+  });
+});
+
+describe('concatDurationDriftError', () => {
+  it('accepts drift within max(0.5s, 2%)', () => {
+    expect(concatDurationDriftError(60, 60.4)).toBeNull();
+    expect(concatDurationDriftError(60, 61.1)).toBeNull(); // 2% of 60 = 1.2s tolerance
+    expect(concatDurationDriftError(10, 10.4)).toBeNull(); // 0.5s floor beats 2%
+  });
+
+  it('names both durations when the joined output does not match its parts', () => {
+    const msg = concatDurationDriftError(60.03, 75.04);
+    expect(msg).toContain('75.04');
+    expect(msg).toContain('60.03');
+    expect(msg).toContain('drift');
+  });
+
+  it('fails open when either duration is unknown', () => {
+    expect(concatDurationDriftError(null, 75)).toBeNull();
+    expect(concatDurationDriftError(60, 0)).toBeNull();
+  });
+});
+
+describe('stereo layout pinning', () => {
+  it('pins a stereo layout in the normalize-loudness chain (mono inputs must not die in layout negotiation)', () => {
+    expect(buildNormalizeLoudnessArgs('in.mp4', 'out.mp4').join(' ')).toContain('aformat=channel_layouts=stereo');
+  });
+
+  it('pins a stereo layout and resamples after loudnorm in the mix filter', () => {
+    const { filter } = buildMixFilter({
+      base: 'b.mp4',
+      baseHasAudio: false,
+      segments: [{ path: 'a.mp3', start_sec: 0 }],
+      on_existing_audio: 'replace',
+      output: 'o.mp4',
+    });
+    expect(filter).toContain('aresample=48000,aformat=channel_layouts=stereo');
+  });
+});

--- a/packages/tools/test/edit-smoke.test.ts
+++ b/packages/tools/test/edit-smoke.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveBinaries, run } from '@orkas/video-studio-core';
-import { probeMedia, trim, concat, loudness, normalizeLoudness, mix } from '../src/edit/edit';
+import { probeMedia, trim, concat, burnsubs, overlay, loudness, normalizeLoudness, mix } from '../src/edit/edit';
 
 const bins = resolveBinaries();
 // Real ffmpeg smoke — runs only where ffmpeg + ffprobe are installed.
@@ -49,6 +49,60 @@ suite('edit smoke (real ffmpeg)', () => {
     const r = await concat([join(dir, 'a.mp4'), join(dir, 'b.mp4')], join(dir, 'joined.mp4'));
     const p = await probeMedia(r.output);
     expect(p.duration).toBeGreaterThan(1.7);
+    expect(r.conform).toBeUndefined();
+  });
+
+  it('conforms mismatched canvas/fps inputs before joining, and reports it', async () => {
+    // The concat demuxer takes canvas + time base from the FIRST input; without
+    // conforming, a 12fps part after a 24fps part is reinterpreted and the
+    // joined duration drifts (24/12 = 2x for that part).
+    const odd = join(dir, 'odd.mp4');
+    await run(bins.ffmpeg as string, [
+      '-y',
+      '-f', 'lavfi', '-i', 'testsrc=size=160x120:rate=12:duration=1',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=1',
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-c:a', 'aac', '-shortest',
+      odd,
+    ]);
+    const r = await concat([join(dir, 'a.mp4'), odd], join(dir, 'joined-mixed.mp4'));
+    expect(r.conform?.applied).toBe(true);
+    expect(r.conform?.target).toBe('320x240@24');
+    expect(r.conform?.conformed_inputs).toHaveLength(1);
+    const p = await probeMedia(r.output);
+    expect(p.width).toBe(320);
+    expect(p.duration).toBeGreaterThan(1.7);
+    expect(p.duration).toBeLessThan(2.4);
+  });
+
+  it('burns CJK subtitles with a script-covering font', async () => {
+    const srt = join(dir, 'zh.srt');
+    writeFileSync(srt, '1\n00:00:00,000 --> 00:00:01,500\n指挥官与协作\n', 'utf8');
+    const r = await burnsubs(src, srt, join(dir, 'subbed.mp4'));
+    expect(existsSync(r.output)).toBe(true);
+    expect((await probeMedia(r.output)).duration).toBeGreaterThan(1.5);
+  });
+
+  it('refuses a full-frame opaque overlay that would erase the base footage', async () => {
+    const card = join(dir, 'card.mp4');
+    await run(bins.ffmpeg as string, [
+      '-y', '-f', 'lavfi', '-i', 'color=c=red:size=320x240:rate=24:duration=1',
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', card,
+    ]);
+    await expect(overlay(src, card, 0, 0, join(dir, 'erased.mp4'))).rejects.toThrow(/replace the base footage/);
+    // A sub-frame opaque overlay (logo box) keeps working.
+    const logo = join(dir, 'logo.mp4');
+    await run(bins.ffmpeg as string, [
+      '-y', '-f', 'lavfi', '-i', 'color=c=blue:size=64x48:rate=24:duration=1',
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', logo,
+    ]);
+    const ok = await overlay(src, logo, 8, 8, join(dir, 'badged.mp4'));
+    expect(existsSync(ok.output)).toBe(true);
+  });
+
+  it('does not leave a partial output behind when ffmpeg fails', async () => {
+    const out = join(dir, 'failed.mp4');
+    await expect(burnsubs(src, join(dir, 'missing.srt'), out)).rejects.toThrow();
+    expect(existsSync(out)).toBe(false);
   });
 
   it('measures integrated loudness', async () => {


### PR DESCRIPTION
Batch 1/8 of the release_1.6.5 sync (edit-op correctness). Re-mapped by hand from Orkas commits `20da5e893`, `61cf39158`, `154c24196`, `8a94dc1c0` — not a file copy.

## Real bugs this fixes in OSS today

1. **`ovs edit concat` silently corrupts mixed-spec joins.** The concat demuxer takes canvas + time base from the *first* input and reinterprets the rest (the incident that motivated the upstream fix: five 1920x1080@15 parts + one 1918x1080@24 cut → 60.03s of material became a 75.04s file, exactly 24/15). Re-encoding — the existing comment's safety net — does not fix this. Now: probe every input, letterbox mismatched parts onto the largest canvas at the highest fps (never crop), post-check the joined duration against the parts' total (fail on drift > max(0.5s, 2%)), and return a `conform` report because re-encoding the caller's material is a delivery change, not an implementation detail.
2. **Mono audio dies in loudness normalization** on ffmpeg builds that refuse the layout negotiation between `aresample` and the aac encoder — and `normalizeDraftAudioIfNeeded` swallows that into `{skipped}` so drafts silently ship un-normalized. Pin `aformat=channel_layouts=stereo` in both the normalize chain and the mix tail (mix also resamples back from loudnorm's internal 192kHz).
3. **CJK captions burn as tofu boxes** on macOS: libass's default family has Japanese coverage, so Simplified-only glyphs render as □ while shared characters look fine — nothing fails, the video ships. `burnsubs` now picks a script-covering family from the subtitle text (kana wins over Han; Latin keeps the platform default).
4. **`ovs edit overlay` erases footage**: a full-frame opaque overlay replaces every base pixel instead of compositing. Fail closed with the real options (edge elements, or plan the beat as a primary segment); sub-frame opaque overlays keep working; fail open on missing probe data.
5. **Failed ffmpeg runs leave partial outputs** that a later existence check reads as a finished edit — now cleaned up on the failure path.

## Verification

`pnpm build` green; **237 tests pass** (baseline 214, +23), including new *real-ffmpeg* regressions: mixed-spec concat conforms to `320x240@24` with a report and a sane duration, CJK burn succeeds with a covering font, full-frame opaque overlay is refused while a logo box passes, and a failed burn leaves no partial file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VL7mRpmEphLAbcH7YmABnV