### PR TITLE
Checkpoint craft: five stops, visual identity, and the direction stop first

### DIFF
--- a/packages/skills/gate-control/SKILL.md
+++ b/packages/skills/gate-control/SKILL.md
@@ -27,6 +27,8 @@ Keep `Gate A/B/C/D` and `HTML Preview` for tool calls, stored state, and technic
 
 Every gate shows the current artifact, a concise next-action/cost/QA note, one decision request, and then stops. A new turn, question, or unrelated message is not approval.
 
+Gate B's review package opens with the locked direction summary — line, aspect, duration, video language, audio mode, supplied-asset usage, and any billable cost note. Do not re-ask a direction fact the user already settled: the plan confirmation restates it, it does not reopen it. A reply naming a different language is a revise instruction — rewrite the plan artifacts to that language and show the one updated confirmation; never approve artifacts that do not match the language you showed.
+
 | Gate | Required artifact | Stable decision field | Approval authorizes |
 | --- | --- | --- | --- |
 | Gate B | script + shotlist or `plan.json` summary, including narration profile | `gate_b_decision` | production from that exact plan |
@@ -47,6 +49,7 @@ Gate C is one batch-level decision. A pending or failed paid request is not reus
 - Legacy `visual_recovery_decision=new_visual_revision` input remains consumable for old clients, but must not be emitted in a new task.
 - An error that says authorization is required does not itself prove recovery availability; query durable status first.
 - A malformed local payload, missing file, stale evidence, failed check, or write error is system work, not a creative decision. Repair it without creating a gate when approved intent is unchanged.
+- A recovery is executed, not narrated: a valid recovery trace contains the concrete file mutation BEFORE the validator retry. Re-running an unchanged validation is not progress, and a diagnosis-only response at that point is incomplete work, not a finished turn.
 
 When production or rendering tools are explicitly unavailable, return a clearly unexecuted production package for an otherwise clear brief: assumptions, complete narration/script, timed storyboard, exact visible copy/captions, visual/audio and rights-safe asset plan, export target, preview checklist, and final playback/encoding QA. Do not claim files exist or withhold the package behind a direction form.
 
@@ -83,7 +86,7 @@ Optional evidence inputs are `--error-code`, `--artifact-state`, `--approval-sta
 
 - A Preview/Gate D `visual_only` revision with recovery `not_available` goes directly to a localized edit and deterministic QA. It emits no recovery question.
 - The same revision with recovery `available` still emits no form: make the localized edit, then use `ovs check`, `ovs snapshot`, and `ovs draft`. OVS automatically starts a fresh persisted repair cycle after the authored content signature changes.
-- A `gate_b_payload` revision creates exactly one Gate B amendment. Its approved signature starts a fresh QA cycle, so recovery from the old signature is irrelevant and must not be combined into the form.
+- A `gate_b_payload` revision creates exactly one Gate B amendment. Its approved signature starts a fresh QA cycle, so recovery from the old signature is irrelevant and must not be combined into the form. The aftermath follows the visual identity: a narration-only amendment keeps the prior silent preview and its go-ahead (scene windows and pixels unchanged), while a visual amendment clears preview evidence — re-run visual QA and the preview only when the visual identity changed.
 - An unchanged artifact with recorded approval continues from that approval; never ask again merely because the task resumed.
 - A passing snapshot may create one Preview Gate. A passing draft may create one Gate D. No status check, advisory, retry, or bookkeeping step creates a user gate.
 - A content edit changes the draft signature and starts a fresh bounded repair cycle automatically. There is no public/manual reset operation; do not delete QA state by hand.

--- a/packages/skills/orchestration/SKILL.md
+++ b/packages/skills/orchestration/SKILL.md
@@ -11,9 +11,17 @@ Read `gate-control` once before the first user gate. It is the single authorizat
 
 ## Checkpoint protocol — how every GATE works (there is no special form UI)
 
-1. **Show the artifact in chat** so the user can actually see it — script/plan as markdown, images inline, a draft video as its output file path — plus one line of "what I'll do next" and any cost/QA note.
+**Show the work; stop only five times.** The stops are a closed set: the direction (Gate A), the production plan (Gate B), paid generation (Gate C), the visual preview, and the final video (Gate D). Showing an artifact is not an ending in itself — publish it in chat and keep going — EXCEPT at the five stops, where the artifact IS the question.
+
+1. **Show the artifact in chat** so the user can actually see it — script/plan as markdown, images inline, a draft video as its output file path — plus one line of "what I'll do next" and any cost/QA note. Deliver it in the message that ENDS the turn: a completed turn keeps only your final message, so frames or artifacts posted mid-turn were never seen by the user.
 2. **State the options** for that gate and **WAIT for the user to reply**. Do not run the next production step in the same turn as the gate.
-3. **On reply, resolve the choice** with `ovs gate transition`: approve → continue only with the returned operation; revise → redo only the authorized scope, re-show, and re-gate only when the resolver says so; abort → stop. Never pass a gate without explicit user confirmation, and never ask again for an unchanged artifact whose approval is already recorded.
+3. **On reply, resolve the choice** with `ovs gate transition`: approve → continue only with the returned operation; revise → redo only the authorized scope, re-show, and re-gate only when the resolver says so; abort → stop. Never pass a gate without explicit user confirmation, and never ask again for an unchanged artifact whose approval is already recorded. A reply picking an option you just enumerated IS that decision — `2`, its wording, or a paraphrase — so act on it in the same turn instead of asking them to restate a choice they already made.
+
+**The visual preview stops once per visual identity.** A change to visible copy, layout, assets, scene order/windows, or motion creates a new identity: capture and show that changed frame set once. Narration text, voice, audio, or narration-timing changes preserve the prior silent frames and their go-ahead when the scene windows and visible output are unchanged — do not re-ask about frames the user already accepted. Frames are presented once as the complete set; rendering before the user has seen them wastes the cheapest correction point.
+
+**Everything you write outside a tool call is user-facing copy**, including progress/process notes before the final message. Keep internal identifiers, finding codes, severity words (`advisory`, `warning`), and frame-role names out of it — use the localized gate names from `gate-control`. A successful preview message has three parts: lead with the contact sheet/frames, say in one short sentence that the preview is ready, then ask one direct question. Passing checks and non-blocking advisories stay silent.
+
+**Repair efficiently.** Every blocking finding a single QA result reports is independent: repair all of them in one message, then run the validator once — fixing them one per message turns one round trip into ten. A successful `edit`/write/tool call is authoritative; do not re-read a file to confirm a write landed — the call would have failed.
 
 ## 1. Route + lock (read `video-router`)
 
@@ -25,7 +33,9 @@ Classify and LOCK the line (no silent switching):
 
 ## 2. GATE A — Proposal (all lines)
 
-Show: the brief you inferred (line, aspect, duration, language) for the user to correct, plus 1–3 differentiated concepts (each: hook + look + rough length; for GENERATE add the shot count and that each clip is a billable call; for AUTO also state the proposed delivery promise — source_led / motion_led / compose_led / hybrid — and the rough segment mix). Options: pick a concept / adjust the brief / new direction. STOP.
+**The direction stop comes first, before any plan file exists.** Show: the brief you inferred (line, aspect, duration, language) for the user to correct, plus 2–3 genuinely DIFFERENT concepts (each: hook + look + rough length; for GENERATE add the shot count and that each clip is a billable call; for AUTO also state the proposed delivery promise — source_led / motion_led / compose_led / hybrid — and the rough segment mix). Options: pick a concept / adjust the brief / new direction. STOP.
+
+Write no script, plan, narration copy, or art direction before their reply — all of that authored against an unchosen direction is work that gets thrown away. A brief that already describes the exact video still stops here, with ONE concept: a misunderstanding costs one message instead of a whole plan. Do not interrogate the user for open creative preferences (casting, audience, style, tone, visual direction) — propose, and let them redirect.
 
 ## 2.5 Craft standard (ALL lines — read `video-craft`)
 
@@ -75,6 +85,8 @@ TALKING-HEAD note: if a GENERATE clip already returned lip-synced built-in speec
 ## AUTO end-to-end line (read `stage-plan`, then `stage-assemble`)
 
 Ingest every supplied clip from evidence (probe + transcribe/OCR-or-frame-reading/extract-frame), author ONE cross-modal `project/plan.json`, `ovs plan validate` and fix every error, **GATE B** on the timeline (`ovs plan summarize`), **GATE C** only if the plan has billable `generate` segments with the exact count and exact `media_kind`/duration/ratio/resolution/audio/reference settings, then assemble per `stage-assemble` (produce each segment via its line, mix narration ONCE, music ducked, burnsubs, normalize loudness). At **GATE D** run `ovs plan promise-check --probe-produced` plus a draft review, then finalize.
+
+**An assembled production is ONE video.** The number of times it stops for the user is fixed by the gate table and never grows with the segment count — seven segments still make exactly one draft review, of the whole video in playback order, never one review per child. An edit to one segment invalidates only that segment: never re-render or re-check an unchanged sibling because another segment changed.
 
 ---
 

--- a/packages/skills/test/skills-content.test.ts
+++ b/packages/skills/test/skills-content.test.ts
@@ -50,6 +50,27 @@ describe('skill pack content', () => {
     expect(orchestration).toContain('gate-control');
   });
 
+  it('carries the checkpoint craft: five stops, visual identity, direction first', () => {
+    const orchestration = skill('orchestration');
+    const router = skill('video-router');
+    const gate = skill('gate-control');
+    // The closed stop set + anti-over-stopping rule.
+    expect(orchestration).toContain('stop only five times');
+    expect(orchestration).toContain('Showing an artifact is not an ending in itself');
+    // The preview re-gates only on a visual-identity change.
+    expect(orchestration).toContain('once per visual identity');
+    expect(orchestration).toContain('preserve the prior silent frames');
+    // The direction stop precedes any plan artifact, in both entry skills.
+    expect(orchestration).toContain('before any plan file exists');
+    expect(router).toContain('Routing ends at the direction stop');
+    // An enumerated-option reply is the decision; frames ride the ending message.
+    expect(orchestration).toContain('IS that decision');
+    expect(orchestration).toContain('message that ENDS the turn');
+    // Assembled stop economics + amendment aftermath by identity.
+    expect(orchestration).toContain('never grows with the segment count');
+    expect(gate).toContain('re-run visual QA and the preview only when the visual identity changed');
+  });
+
   it('wires the design layers into compose and orchestration', () => {
     const compose = skill('stage-compose');
     const orchestration = skill('orchestration');

--- a/packages/skills/video-router/SKILL.md
+++ b/packages/skills/video-router/SKILL.md
@@ -39,6 +39,10 @@ Pick a **single line** when one axis cleanly dominates (just trim a clip; just a
 
 AUTO does not abandon the axes — it sequences them through one cross-modal plan (`stage-plan` builds the EDL, `stage-assemble` walks it), delegating each segment back to the generate / compose / edit lines. Choosing AUTO is itself the lock: the *primary* still gets named via the plan's `delivery_promise` (source_led / motion_led / compose_led / hybrid).
 
+## Routing ends at the direction boundary
+
+Routing ends at the direction stop (Gate A), not at a production plan. Present only 2–3 direction concepts plus the facts the brief already locked, and write NO plan file, script, narration copy, or art direction before the user picks a direction — everything authored against an unchosen direction is thrown away when they pick another.
+
 ## Lock the runtime
 
 - Decide the primary axis at the brief/proposal stage and **state it in the proposal**.


### PR DESCRIPTION
Batch 6/8 of the release_1.6.5 sync (checkpoint craft, prompt-only). Stacked on #18. Re-mapped by hand from the net end-state of the upstream Aug 1-10 gate/orchestration iteration (`c4ba98815`, `707a8bf1f`, `734cfc675`, `ed5d22684`, `2182ad89a`, `72e541a87`).

## What this adds (all prompt-level, all absent from OSS today)

1. **"Show the work; stop only five times."** OSS's checkpoint protocol says when to stop but never the anti-over-stopping half — that showing an artifact is *not* itself an ending. The five stops are now a closed set.
2. **The visual preview stops once per visual identity.** Narration/audio-only changes preserve the accepted silent frames; only a change to visible copy/layout/assets/windows/motion re-gates. Without this an OSS agent re-previews after every narration tweak. (Consistent with the PR5 resolver's amendment-aftermath reasons.)
3. **The direction stop comes first, before any plan file exists** (orchestration Gate A + video-router). OSS's compose runbook currently starts *after* Gate B, and nothing stops an agent from authoring the whole plan before the user has picked a direction — upstream measured 11 minutes of thrown-away authoring. An exact brief still stops, with one concept: a misunderstanding costs one message instead of a whole plan.
4. **Turn mechanics that survive summarized transcripts:** artifacts ride the message that ENDS the turn (mid-turn frames were never seen); an enumerated-option reply ("2", its wording, or a paraphrase) IS the decision — act on it, don't re-ask.
5. **Presentation copy:** progress prose is user-facing; no finding codes/severity words/internal frame roles; a passing preview message = sheet → one sentence → one question; passing checks stay silent.
6. **Repair economics:** all independent blocking findings from one QA result get repaired in ONE message (upstream: one-per-message cost ~10 minutes for six findings); a successful write is authoritative — never re-read to confirm it.
7. **AUTO stop economics:** an assembled production is ONE video — stop count fixed by the gate table, one whole-video review, an edit invalidates only its own segment.
8. **gate-control:** Gate B restates settled direction facts instead of reopening them; a different-language reply is a revise instruction; a recovery is *executed, not narrated*.

## Verification

Prompt-only; the skills content test pins each new clause (`stop only five times`, `once per visual identity`, `before any plan file exists`, `Routing ends at the direction stop`, …). Full suite 266 pass / 11 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VL7mRpmEphLAbcH7YmABnV