### PR TITLE
The whole-video production preview: one sheet, segments in playback order

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,7 @@ import {
   resolveGateTransition,
 } from '@orkas/video-studio-core';
 import type { VideoEdl, Take, QualityThresholds, GateTransitionInput } from '@orkas/video-studio-core';
-import { edit, render as renderTool, composition as compositionTool, analyze, speech, image, video, collectProducedSec } from '@orkas/video-studio-tools';
+import { edit, render as renderTool, composition as compositionTool, analyze, speech, image, video, collectProducedSec, productionPreview } from '@orkas/video-studio-tools';
 import type { EditProgressEvent } from '@orkas/video-studio-tools';
 import { listSkills, readSkill, installSkills, type InstallTarget, type InstallScope } from './skills.js';
 
@@ -452,6 +452,17 @@ const plan = defineCommand({
         const a = assessDelivery(plan, producedSec ? { producedSec } : {});
         printJson(producedSec ? { ...a, produced_sec: producedSec } : a);
         if (a.verdict === 'fail') process.exitCode = 1;
+      },
+    }),
+    preview: defineCommand({
+      meta: { name: 'preview', description: 'Build the whole-video production contact sheet from the assembled draft — one frame per primary segment in playback order. Lead Gate D with this; per-segment sheets are not a look at the video.' },
+      args: {
+        file: { type: 'positional', required: true, description: 'plan.json' },
+        video: { type: 'string', required: true, description: 'the assembled draft/final video file' },
+        'out-dir': { type: 'string', required: true, description: 'directory for the frames and contact sheet' },
+      },
+      async run({ args }) {
+        printJson(await productionPreview(String(args.file), String(args.video), String(args['out-dir'])));
       },
     }),
     'rank-takes': defineCommand({

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -16,7 +16,7 @@ import {
   resolveGateTransition,
 } from '@orkas/video-studio-core';
 import type { VideoEdl } from '@orkas/video-studio-core';
-import { edit, render as renderTool, composition as compositionTool, analyze, speech, image, video, collectProducedSec } from '@orkas/video-studio-tools';
+import { edit, render as renderTool, composition as compositionTool, analyze, speech, image, video, collectProducedSec, productionPreview } from '@orkas/video-studio-tools';
 import type { EditProgressEvent } from '@orkas/video-studio-tools';
 import { listSkills, readSkill } from './skills.js';
 
@@ -87,6 +87,12 @@ server.tool('snapshot', 'Capture hook, per-scene, and payoff preview frames plus
 server.tool('composition_prepare', 'Create a HyperFrames scaffold from composition-manifest.json without overwriting authored HTML.', { project: z.string() }, ({ project }) => format(compositionTool.prepareComposition(project)));
 server.tool('composition_reconcile', 'Apply manifest timing/audio metadata while preserving authored visual content.', { project: z.string() }, ({ project }) => format(compositionTool.reconcileComposition(project)));
 server.tool('composition_script', 'Render composition-manifest.json as the readable production plan — present this at the plan confirmation instead of hand-writing a script file.', { project: z.string() }, ({ project }) => format(compositionTool.compositionScript(project)));
+server.tool(
+  'plan_preview',
+  'Build the whole-video production contact sheet from the assembled draft — one frame per primary segment in playback order. Lead the draft review with this; per-segment sheets are not a look at the video.',
+  { file: z.string(), video: z.string(), out_dir: z.string() },
+  ({ file, video: videoPath, out_dir }) => format(productionPreview(file, videoPath, out_dir)),
+);
 
 // --- edit (ffmpeg) ---------------------------------------------------------
 server.tool('edit_probe', 'Probe duration/resolution/fps/audio.', { input: z.string() }, ({ input }) => format(edit.probeMedia(input)));

--- a/packages/skills/orchestration/SKILL.md
+++ b/packages/skills/orchestration/SKILL.md
@@ -86,7 +86,7 @@ TALKING-HEAD note: if a GENERATE clip already returned lip-synced built-in speec
 
 Ingest every supplied clip from evidence (probe + transcribe/OCR-or-frame-reading/extract-frame), author ONE cross-modal `project/plan.json`, `ovs plan validate` and fix every error, **GATE B** on the timeline (`ovs plan summarize`), **GATE C** only if the plan has billable `generate` segments with the exact count and exact `media_kind`/duration/ratio/resolution/audio/reference settings, then assemble per `stage-assemble` (produce each segment via its line, mix narration ONCE, music ducked, burnsubs, normalize loudness). At **GATE D** run `ovs plan promise-check --probe-produced` plus a draft review, then finalize.
 
-**An assembled production is ONE video.** The number of times it stops for the user is fixed by the gate table and never grows with the segment count — seven segments still make exactly one draft review, of the whole video in playback order, never one review per child. An edit to one segment invalidates only that segment: never re-render or re-check an unchanged sibling because another segment changed.
+**An assembled production is ONE video.** The number of times it stops for the user is fixed by the gate table and never grows with the segment count — seven segments still make exactly one draft review, of the whole video in playback order, never one review per child. Lead that review with the whole-video contact sheet from `ovs plan preview` (one frame per primary segment, media segments included). An edit to one segment invalidates only that segment: never re-render or re-check an unchanged sibling because another segment changed.
 
 ---
 

--- a/packages/skills/stage-assemble/SKILL.md
+++ b/packages/skills/stage-assemble/SKILL.md
@@ -54,7 +54,11 @@ For a partial child failure or later revision, reset only the affected child and
 
 ## Step 4 — QA report, then gate D
 
-Before showing the draft, run the QA pass and write `project/render_report.json`. It judges the delivered ARTIFACT against the approved plan — length, canvas, narration placement measured from real speech, loudness, declared captions — so every route to the file meets the same bar, including a hand-written ffmpeg assembly. Sections:
+Before showing the draft, build the whole-video preview and run the QA pass.
+
+**Production preview** — `ovs plan preview project/plan.json --video project/render/draft.mp4 --out-dir project/render/preview` builds ONE contact sheet of the whole video: the cover plus one frame per primary segment in playback order, media segments included as an extracted still. LEAD the Gate D message with this sheet. Never present per-segment contact sheets as the production preview — four links to four children is not a look at the video — and never add per-segment approval stops: the production is reviewed as one video (see orchestration's AUTO rules).
+
+Then run the QA pass and write `project/render_report.json`. It judges the delivered ARTIFACT against the approved plan — length, canvas, narration placement measured from real speech, loudness, declared captions — so every route to the file meets the same bar, including a hand-written ffmpeg assembly. Sections:
 
 - **technical_probe** — `ovs edit probe` the draft/final (real duration / resolution / fps / audio present); confirm it matches the plan's aspect + total.
 - **promise_preservation** — `ovs plan promise-check project/plan.json --probe-produced`. At gate D this probes each primary segment's `produced_path` and computes the REAL primary-track motion ratio vs. `motion_min_ratio` plus the `source_required` invariant; missing/unreadable produced media or a fail means **"slideshow / promise broken" — do not deliver**. Send it back (below). Do not eyeball this; let the numbers decide.

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -12,5 +12,7 @@ export { editVideo, probeMedia } from './edit/index.js';
 export type { EditOp, ProbeResult } from './edit/index.js';
 export type { EditProgressEvent, OnEditProgress, EditRunOptions } from './progress.js';
 export { collectProducedSec, resolveProducedPath } from './plan-produced.js';
+export { buildProductionPreviewPlan, productionPreview } from './production-preview.js';
+export type { ProductionPreviewResult, ProductionPreviewSample } from './production-preview.js';
 export * from './hyperframes/index.js';
 export * from './composition/index.js';

--- a/packages/tools/src/production-preview.ts
+++ b/packages/tools/src/production-preview.ts
@@ -1,0 +1,129 @@
+/**
+ * The whole-video production preview: ONE contact sheet of the assembled
+ * draft, segments in playback order — media segments included as an extracted
+ * still. An assembled production is reviewed as one video; presenting one
+ * sheet per child segment is four links to four children, not a look at the
+ * video, and it multiplies the user's stops by the segment count.
+ */
+import { readFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { extractFrame, probeMedia } from './edit/edit.js';
+import { writeFrameContactSheet, type FrameSampleEvidence } from './render/composition-qa.js';
+
+/** Sheet-size sanity cap; a plan longer than this reports the truncation. */
+const PREVIEW_MAX_SEGMENTS = 24;
+
+export interface ProductionPreviewSample {
+  segment_id: string;
+  order: number;
+  label: string;
+  time_seconds: number;
+}
+
+export interface ProductionPreviewResult {
+  ok: true;
+  video: string;
+  video_duration_sec: number;
+  contact_sheet: string;
+  frames: Array<ProductionPreviewSample & { path: string }>;
+  warnings: string[];
+}
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+/**
+ * Pure: one sample per primary segment — the midpoint of its window on the
+ * assembled timeline — plus the cover at t=0. Windows come from the plan's
+ * `target_sec` proportions scaled to the REAL video duration, so drift between
+ * planned and produced lengths shifts every midpoint proportionally instead of
+ * sampling past the end.
+ */
+export function buildProductionPreviewPlan(
+  segments: unknown,
+  videoDurationSec: number,
+): { samples: ProductionPreviewSample[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const duration = Number.isFinite(videoDurationSec) && videoDurationSec > 0 ? videoDurationSec : 0;
+  const lastSeekable = Math.max(0, round1(duration - 0.1));
+  const samples: ProductionPreviewSample[] = [
+    { segment_id: 'cover', order: 0, label: 'cover', time_seconds: 0 },
+  ];
+  const primaries = (Array.isArray(segments) ? segments : [])
+    .filter((seg): seg is Record<string, unknown> => !!seg && typeof seg === 'object' && !Array.isArray(seg))
+    .filter((seg) => seg.layer === 'primary' && Number.isFinite(Number(seg.target_sec)) && Number(seg.target_sec) > 0)
+    .sort((a, b) => Number(a.order ?? 0) - Number(b.order ?? 0));
+  if (!primaries.length || duration <= 0) return { samples, warnings };
+
+  const kept = primaries.slice(0, PREVIEW_MAX_SEGMENTS);
+  if (kept.length < primaries.length) {
+    warnings.push(`Sheet covers the first ${PREVIEW_MAX_SEGMENTS} of ${primaries.length} primary segments.`);
+  }
+  const totalTarget = primaries.reduce((sum, seg) => sum + Number(seg.target_sec), 0);
+  const scale = duration / totalTarget;
+  let startSec = 0;
+  kept.forEach((seg, index) => {
+    const windowSec = Number(seg.target_sec) * scale;
+    const mid = Math.min(lastSeekable, round1(startSec + windowSec / 2));
+    const id = String(seg.id ?? `segment-${index + 1}`);
+    samples.push({
+      segment_id: id,
+      order: Number(seg.order ?? index + 1),
+      label: `${index + 1}-${id}`,
+      time_seconds: mid,
+    });
+    startSec += windowSec;
+  });
+  return { samples, warnings };
+}
+
+/** Build the production contact sheet from the assembled draft/final file. */
+export async function productionPreview(
+  planPath: string,
+  videoPath: string,
+  outDir: string,
+): Promise<ProductionPreviewResult> {
+  const video = resolve(videoPath);
+  const dir = resolve(outDir);
+  let plan: unknown;
+  try {
+    plan = JSON.parse(readFileSync(resolve(planPath), 'utf8'));
+  } catch (error) {
+    throw new Error(`production preview: could not read/parse plan "${planPath}": ${(error as Error).message}`);
+  }
+  const segments = plan && typeof plan === 'object' && !Array.isArray(plan)
+    ? (plan as Record<string, unknown>).segments
+    : undefined;
+  const probe = await probeMedia(video);
+  if (!(probe.duration > 0)) throw new Error('production preview: the assembled video has no measurable duration.');
+  const { samples, warnings } = buildProductionPreviewPlan(segments, probe.duration);
+
+  await mkdir(dir, { recursive: true });
+  const frames: ProductionPreviewResult['frames'] = [];
+  const sheetSamples: FrameSampleEvidence[] = [];
+  for (const sample of samples) {
+    const framePath = join(dir, `${sample.label}.png`);
+    await extractFrame(video, sample.time_seconds, framePath);
+    frames.push({ ...sample, path: framePath });
+    sheetSamples.push({
+      label: sample.label,
+      time_seconds: sample.time_seconds,
+      frame_index: Math.round(sample.time_seconds * (probe.fps || 30)),
+      path: framePath,
+      hash: '',
+      brightness: 0,
+      contrast: 0,
+      width: probe.width,
+      height: probe.height,
+    });
+  }
+  const contactSheet = await writeFrameContactSheet(dir, sheetSamples);
+  return {
+    ok: true,
+    video,
+    video_duration_sec: probe.duration,
+    contact_sheet: contactSheet,
+    frames,
+    warnings,
+  };
+}

--- a/packages/tools/test/production-preview.test.ts
+++ b/packages/tools/test/production-preview.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveBinaries, run } from '@orkas/video-studio-core';
+import { buildProductionPreviewPlan, productionPreview } from '../src/production-preview';
+
+describe('buildProductionPreviewPlan', () => {
+  const segments = [
+    { id: 's1_hook', order: 1, layer: 'primary', target_sec: 6 },
+    { id: 's2_cap', order: 2, layer: 'overlay', target_sec: 3 },
+    { id: 's3_body', order: 3, layer: 'primary', target_sec: 8 },
+    { id: 's4_cta', order: 4, layer: 'primary', target_sec: 6 },
+  ];
+
+  it('samples the cover plus each primary segment midpoint, scaled to the real duration', () => {
+    // Planned primaries total 20s but the real cut is 10s → every window halves.
+    const { samples, warnings } = buildProductionPreviewPlan(segments, 10);
+    expect(warnings).toEqual([]);
+    expect(samples.map((s) => s.label)).toEqual(['cover', '1-s1_hook', '2-s3_body', '3-s4_cta']);
+    expect(samples[1].time_seconds).toBeCloseTo(1.5, 1); // 0..3 window
+    expect(samples[2].time_seconds).toBeCloseTo(5, 1); // 3..7 window
+    expect(samples[3].time_seconds).toBeCloseTo(8.5, 1); // 7..10 window
+  });
+
+  it('never samples past the last seekable moment', () => {
+    const { samples } = buildProductionPreviewPlan([{ id: 'only', order: 1, layer: 'primary', target_sec: 5 }], 0.3);
+    expect(samples.every((s) => s.time_seconds <= 0.3)).toBe(true);
+  });
+
+  it('degrades to the cover alone without primaries or a duration', () => {
+    expect(buildProductionPreviewPlan([], 10).samples.map((s) => s.label)).toEqual(['cover']);
+    expect(buildProductionPreviewPlan(segments, 0).samples.map((s) => s.label)).toEqual(['cover']);
+    expect(buildProductionPreviewPlan(undefined, 10).samples.map((s) => s.label)).toEqual(['cover']);
+  });
+
+  it('caps the sheet and says what was dropped', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ id: `s${i}`, order: i + 1, layer: 'primary', target_sec: 2 }));
+    const { samples, warnings } = buildProductionPreviewPlan(many, 60);
+    expect(samples).toHaveLength(25); // cover + 24
+    expect(warnings.join(' ')).toContain('first 24 of 30');
+  });
+});
+
+const bins = resolveBinaries();
+const suite = bins.ffmpeg && bins.ffprobe ? describe : describe.skip;
+
+suite('productionPreview (real ffmpeg)', () => {
+  const dir = join(tmpdir(), `ovs-prod-preview-${process.pid}`);
+  const video = join(dir, 'assembled.mp4');
+
+  beforeAll(async () => {
+    mkdirSync(dir, { recursive: true });
+    await run(bins.ffmpeg as string, [
+      '-y', '-f', 'lavfi', '-i', 'testsrc=size=320x240:rate=24:duration=4',
+      '-c:v', 'libx264', '-pix_fmt', 'yuv420p', video,
+    ]);
+    writeFileSync(join(dir, 'plan.json'), JSON.stringify({
+      segments: [
+        { id: 'hook', order: 1, layer: 'primary', target_sec: 2 },
+        { id: 'payoff', order: 2, layer: 'primary', target_sec: 2 },
+      ],
+    }), 'utf8');
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('extracts one frame per primary segment and composes one sheet', async () => {
+    const result = await productionPreview(join(dir, 'plan.json'), video, join(dir, 'preview'));
+    expect(result.ok).toBe(true);
+    expect(result.frames.map((f) => f.label)).toEqual(['cover', '1-hook', '2-payoff']);
+    for (const frame of result.frames) expect(existsSync(frame.path)).toBe(true);
+    expect(existsSync(result.contact_sheet)).toBe(true);
+    const sheet = readFileSync(result.contact_sheet, 'utf8');
+    expect(sheet).toContain('1-hook');
+    expect(sheet).toContain('2-payoff');
+  });
+});


### PR DESCRIPTION
Batch 10 of the release_1.6.5 sync. Stacked on #22. Re-mapped by hand from Orkas commits `3b9451d78` ("put every segment in the production preview, media included"), `c072d58ef` ("lead the production preview with the whole-video sheet"), `2182ad89a` ("review an assembled video as one video").

## Why

Batch 6 (#19) landed the rule — *an assembled production is ONE video; the stop count never grows with the segment count* — but OSS had no tool that produces a whole-video look: contact sheets were per-composition only, so the only honest presentations were per-segment sheets (four links to four children) or nothing.

## What

- **`ovs plan preview <plan.json> --video <draft> --out-dir <dir>`** (+ MCP `plan_preview`): probes the assembled draft, samples the cover plus one frame per **primary** segment at the midpoint of its window — `target_sec` proportions scaled to the *real* duration, so planned-vs-produced drift shifts midpoints proportionally instead of seeking past the end — extracts the frames, and composes ONE contact sheet. Capped at 24 segments with the truncation *reported*, never silent.
- **stage-assemble** leads Gate D with this sheet; per-segment sheets and per-segment approval stops are named anti-patterns. **orchestration**'s AUTO stop-economics rule now points at the command that makes it executable.
- Deliberately not ported: upstream's production-scope batched QA phases and `uncaptured_segment_ids` — those need a production state machine OSS doesn't have. The review-side value lands without it.

## Verification

Full `OVS_E2E=1` suite **283/284**. Unit: midpoint scaling (20s planned on a 10s cut halves every window), last-seekable clamp, cover-only degradation, cap reporting. Real ffmpeg: a 4s assembled clip → cover + two segment frames on disk + one SVG sheet naming both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VL7mRpmEphLAbcH7YmABnV