### PR TITLE
feat(video): add MuAPI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,21 @@ opt-in and uses **your** keys — no managed backend, no account binding. Config
 | Capability | Providers | Env |
 |---|---|---|
 | Image (`ovs image`) | OpenAI-compatible · Gemini · Doubao Seedream | `OVS_IMAGE_PROVIDER` · `OVS_IMAGE_BASE_URL` · `OVS_IMAGE_API_KEY` · `OVS_IMAGE_MODEL` |
-| Video (`ovs video`) | Doubao Seedance (image-to-video) | `OVS_VIDEO_PROVIDER` · `OVS_VIDEO_BASE_URL` · `OVS_VIDEO_API_KEY` · `OVS_VIDEO_MODEL` |
+| Video (`ovs video`) | Doubao Seedance · Atlas Cloud · MuAPI | `OVS_VIDEO_PROVIDER` · `OVS_VIDEO_BASE_URL` · `OVS_VIDEO_API_KEY` · `OVS_VIDEO_MODEL` |
 | TTS (`ovs speak`) | OpenAI-compatible (incl. ElevenLabs-style) | `OVS_TTS_BASE_URL` · `OVS_TTS_API_KEY` · `OVS_TTS_MODEL` · `OVS_TTS_VOICE` · `OVS_TTS_FORMAT` |
 
 Use `ovs speech-capabilities` to resolve the exact configured narration profile without
 printing credentials, then `ovs narration fit` before and after synthesis to keep each line
 inside its plan window. Video generation accepts explicit reference images, ratio, duration,
 resolution, and audio generation flags so the provider call matches the approved plan.
+
+For [MuAPI](https://muapi.ai), set `video.provider` to `"muapi"` and provide `MUAPI_API_KEY` (or
+use `OVS_VIDEO_API_KEY`). `video.model` / `OVS_VIDEO_MODEL` accepts a MuAPI endpoint slug;
+text-to-video defaults to `kling-v2.1-master-t2v`, while a first-frame `image_url` defaults to
+`kling-v2.1-standard-i2v`. See the [MuAPI API reference](https://muapi.ai/docs/api-reference)
+for the submit-and-poll contract and model-specific parameters. This adapter exposes the
+common prompt, aspect-ratio, duration, and first-frame inputs; resolution, audio, edit, and
+additional-reference controls remain provider-specific.
 
 ---
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -639,8 +639,8 @@ const videoCmd = defineCommand({
     quality: { type: 'string', description: 'economy | balanced | quality (provider-neutral intent)' },
     ratio: { type: 'string', default: '16:9', description: '16:9 | 9:16 | 1:1 | 4:3 | 3:4 | 21:9' },
     duration: { type: 'string', default: '5', description: '4-15 seconds' },
-    resolution: { type: 'string', default: '720p', description: '480p | 720p | 1080p' },
-    'generate-audio': { type: 'boolean', default: true },
+    resolution: { type: 'string', description: '480p | 720p | 1080p' },
+    'generate-audio': { type: 'boolean', description: 'request provider-generated audio when supported' },
   },
   async run({ args }) {
     const referenceImageUrls = args['image-urls']
@@ -660,8 +660,8 @@ const videoCmd = defineCommand({
       quality: args.quality ? String(args.quality) as 'economy' | 'balanced' | 'quality' : undefined,
       ratio: String(args.ratio) as '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | '21:9',
       duration: num(args.duration, 'duration'),
-      resolution: String(args.resolution) as '480p' | '720p' | '1080p',
-      generate_audio: args['generate-audio'] !== false,
+      resolution: args.resolution ? String(args.resolution) as '480p' | '720p' | '1080p' : undefined,
+      generate_audio: args['generate-audio'] === undefined ? undefined : args['generate-audio'] !== false,
     }));
   },
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -21,7 +21,7 @@ export interface ImageProviderConfig {
   model?: string;
 }
 export interface VideoProviderConfig {
-  provider?: 'doubao' | 'atlas';
+  provider?: 'doubao' | 'atlas' | 'muapi';
   base_url?: string;
   api_key?: string;
   model?: string;
@@ -71,11 +71,20 @@ export function loadConfig(): OvsConfig {
     ...(process.env.OVS_IMAGE_API_KEY ? { api_key: process.env.OVS_IMAGE_API_KEY } : {}),
     ...(process.env.OVS_IMAGE_MODEL ? { model: process.env.OVS_IMAGE_MODEL } : {}),
   };
+  const configuredVideoProvider = process.env.OVS_VIDEO_PROVIDER as VideoProviderConfig['provider'] | undefined;
+  const fileVideoProvider = fromFile.video?.provider;
+  const useMuapiEnvKey = Boolean(process.env.MUAPI_API_KEY) &&
+    (configuredVideoProvider === 'muapi' || fileVideoProvider === 'muapi' || (!configuredVideoProvider && !fileVideoProvider));
+  const muapiEnvProvider = !configuredVideoProvider && !fileVideoProvider && useMuapiEnvKey ? 'muapi' as const : undefined;
   const video: VideoProviderConfig = {
     ...fromFile.video,
-    ...(process.env.OVS_VIDEO_PROVIDER ? { provider: process.env.OVS_VIDEO_PROVIDER as VideoProviderConfig['provider'] } : {}),
+    ...(configuredVideoProvider ? { provider: configuredVideoProvider } : muapiEnvProvider ? { provider: muapiEnvProvider } : {}),
     ...(process.env.OVS_VIDEO_BASE_URL ? { base_url: process.env.OVS_VIDEO_BASE_URL } : {}),
-    ...(process.env.OVS_VIDEO_API_KEY ? { api_key: process.env.OVS_VIDEO_API_KEY } : {}),
+    ...(process.env.OVS_VIDEO_API_KEY
+      ? { api_key: process.env.OVS_VIDEO_API_KEY }
+      : useMuapiEnvKey
+        ? { api_key: process.env.MUAPI_API_KEY }
+        : {}),
     ...(process.env.OVS_VIDEO_MODEL ? { model: process.env.OVS_VIDEO_MODEL } : {}),
   };
   const out: OvsConfig = { ...fromFile };

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -254,7 +254,7 @@ server.tool(
 );
 server.tool(
   'video',
-  'Generate a video clip via the configured BYO provider (Doubao Seedance), with exact Gate C settings.',
+  'Generate a video clip via the configured BYO provider (Doubao Seedance, Atlas Cloud, or MuAPI), with exact Gate C settings.',
   {
     prompt: z.string(),
     output: z.string(),

--- a/packages/tools/src/video/video.ts
+++ b/packages/tools/src/video/video.ts
@@ -11,6 +11,9 @@ const ATLAS_DEFAULT_MODEL = 'bytedance/seedance-2.0/text-to-video';
 // model's schema has no `image` field — a first frame sent to it is ignored
 // or rejected, never used.
 const ATLAS_DEFAULT_I2V_MODEL = 'bytedance/seedance-2.0/image-to-video';
+const MUAPI_DEFAULT_BASE = 'https://api.muapi.ai/api/v1';
+const MUAPI_DEFAULT_T2V_MODEL = 'kling-v2.1-master-t2v';
+const MUAPI_DEFAULT_I2V_MODEL = 'kling-v2.1-standard-i2v';
 const POLL_INTERVAL_MS = 10_000;
 const POLL_TIMEOUT_MS = 30_000; // per-poll request timeout — one slow poll must not fail the task
 const TASK_TIMEOUT_MS = 60 * 60 * 1000;
@@ -48,6 +51,10 @@ function atlasBase(cfg: VideoProviderConfig): string {
   return (cfg.base_url ?? ATLAS_DEFAULT_BASE).replace(/\/+$/, '');
 }
 
+function muapiBase(cfg: VideoProviderConfig): string {
+  return (cfg.base_url ?? MUAPI_DEFAULT_BASE).replace(/\/+$/, '');
+}
+
 /** Build an Atlas Cloud media task request (`POST {base}/model/generateVideo`). */
 export function buildAtlasCreateRequest(cfg: VideoProviderConfig, p: VideoParams): ProviderRequest {
   if (!cfg.api_key) throw new Error('video: no api_key configured');
@@ -82,6 +89,48 @@ export function buildAtlasCreateRequest(cfg: VideoProviderConfig, p: VideoParams
       ratio: p.ratio ?? '16:9',
       generate_audio: p.generate_audio !== false,
       ...(p.image_url ? { image: p.image_url } : {}),
+    },
+  };
+}
+
+/** Build a MuAPI submit request (`POST {base}/{model-endpoint}`). */
+export function buildMuapiCreateRequest(cfg: VideoProviderConfig, p: VideoParams): ProviderRequest {
+  if (!cfg.api_key) throw new Error('video: no api_key configured');
+  if (!p.prompt.trim()) throw new Error('video: prompt is required');
+  if (p.operation !== undefined && p.operation !== 'generate') {
+    throw new Error('video: MuAPI currently supports the generate operation');
+  }
+  if (p.reference_image_urls?.length || p.reference_video_urls?.length) {
+    throw new Error('video: MuAPI currently accepts one first-frame image_url; additional references are not supported');
+  }
+  if (p.resolution !== undefined || p.generate_audio !== undefined) {
+    throw new Error('video: MuAPI resolution and audio controls are model-specific and are not supported by this adapter');
+  }
+  const duration = p.duration ?? 5;
+  if (!Number.isInteger(duration) || duration <= 0) {
+    throw new Error('video: duration must be a positive integer');
+  }
+  const ratio = p.ratio ?? '16:9';
+  if (!['16:9', '9:16', '1:1'].includes(ratio)) {
+    throw new Error('video: MuAPI supports 16:9, 9:16, and 1:1 aspect ratios');
+  }
+  const model = p.model ?? cfg.model ?? (p.image_url ? MUAPI_DEFAULT_I2V_MODEL : MUAPI_DEFAULT_T2V_MODEL);
+  const looksLikeI2v = /(?:image-to-video|i2v)/i.test(model);
+  const looksLikeT2v = /(?:text-to-video|t2v)/i.test(model);
+  if (p.image_url && looksLikeT2v) {
+    throw new Error(`video: model "${model}" is text-to-video; use an image-to-video model for image_url`);
+  }
+  if (!p.image_url && looksLikeI2v) {
+    throw new Error(`video: model "${model}" requires a first-frame image_url`);
+  }
+  return {
+    url: `${muapiBase(cfg)}/${model}`,
+    headers: { 'x-api-key': cfg.api_key, 'content-type': 'application/json' },
+    body: {
+      prompt: p.prompt,
+      aspect_ratio: ratio,
+      duration,
+      ...(p.image_url ? { image_url: p.image_url } : {}),
     },
   };
 }
@@ -146,6 +195,14 @@ interface AtlasResp {
     error?: string;
   };
 }
+interface MuapiCreateResp {
+  request_id?: string;
+}
+interface MuapiPollResp {
+  status?: string;
+  outputs?: string[];
+  error?: string | { message?: string };
+}
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -200,30 +257,39 @@ export async function generateVideo(params: VideoParams, config: OvsConfig = loa
   const interval = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
 
   const provider = cfg.provider ?? 'doubao';
-  const req = provider === 'atlas' ? buildAtlasCreateRequest(cfg, params) : buildSeedanceCreateRequest(cfg, params);
-  const created = (await postJson(req.url, req.body, req.headers, POLL_TIMEOUT_MS)) as CreateResp & AtlasResp;
-  const id = provider === 'atlas' ? created.data?.id : created.id;
+  const req = provider === 'atlas'
+    ? buildAtlasCreateRequest(cfg, params)
+    : provider === 'muapi'
+      ? buildMuapiCreateRequest(cfg, params)
+      : buildSeedanceCreateRequest(cfg, params);
+  const created = (await postJson(req.url, req.body, req.headers, POLL_TIMEOUT_MS)) as CreateResp & AtlasResp & MuapiCreateResp;
+  const id = provider === 'atlas' ? created.data?.id : provider === 'muapi' ? created.request_id : created.id;
   if (!id) throw new Error('video: task create returned no id');
 
-  const base = provider === 'atlas' ? atlasBase(cfg) : arkBase(cfg);
-  const authHeaders = { authorization: `Bearer ${cfg.api_key}` };
+  const base = provider === 'atlas' ? atlasBase(cfg) : provider === 'muapi' ? muapiBase(cfg) : arkBase(cfg);
+  const authHeaders: Record<string, string> = provider === 'muapi'
+    ? { 'x-api-key': cfg.api_key }
+    : { authorization: `Bearer ${cfg.api_key}` };
   const start = now();
 
   for (;;) {
     if (now() - start > TASK_TIMEOUT_MS) throw new Error(`video: task ${id} timed out after ${TASK_TIMEOUT_MS}ms`);
     const pollUrl = provider === 'atlas'
       ? `${base}/model/prediction/${id}`
-      : `${base}/contents/generations/tasks/${id}`;
-    const response = (await getJson(pollUrl, authHeaders, POLL_TIMEOUT_MS)) as PollResp & AtlasResp;
+      : provider === 'muapi'
+        ? `${base}/predictions/${id}/result`
+        : `${base}/contents/generations/tasks/${id}`;
+    const response = (await getJson(pollUrl, authHeaders, POLL_TIMEOUT_MS)) as PollResp & AtlasResp & MuapiPollResp;
     const atlasPoll = provider === 'atlas' ? response.data : undefined;
+    const muapiPoll = provider === 'muapi' ? response : undefined;
     const doubaoPoll = provider === 'atlas' ? undefined : response;
-    const status = atlasPoll?.status ?? doubaoPoll?.status;
+    const status = atlasPoll?.status ?? muapiPoll?.status ?? doubaoPoll?.status;
     const succeeded = status === 'succeeded' || status === 'completed';
     if (succeeded) {
       const atlasOutput = provider === 'atlas'
         ? (Array.isArray(atlasPoll?.output) ? atlasPoll.output[0] : atlasPoll?.output) ?? atlasPoll?.outputs?.[0]
         : undefined;
-      const url = provider === 'atlas' ? atlasOutput : doubaoPoll?.content?.video_url;
+      const url = provider === 'atlas' ? atlasOutput : provider === 'muapi' ? muapiPoll?.outputs?.[0] : doubaoPoll?.content?.video_url;
       if (!url) throw new Error(`video: task ${id} succeeded but returned no video_url`);
       const dl = await fetchWithTimeout(url, { method: 'GET', timeoutMs: DOWNLOAD_TIMEOUT_MS });
       if (!dl.ok) throw new Error(`video download failed with HTTP ${dl.status}`);
@@ -241,7 +307,10 @@ export async function generateVideo(params: VideoParams, config: OvsConfig = loa
       return { output: resolve(params.output), bytes: buf.byteLength, task_id: id };
     }
     if (status === 'failed' || status === 'canceled') {
-      throw new Error(`video: task ${id} ${status}`);
+      const detail = provider === 'muapi'
+        ? typeof muapiPoll?.error === 'string' ? muapiPoll.error : muapiPoll?.error?.message
+        : undefined;
+      throw new Error(`video: task ${id} ${status}${detail ? `: ${detail}` : ''}`);
     }
     await sleep(interval);
   }

--- a/packages/tools/test/gen.test.ts
+++ b/packages/tools/test/gen.test.ts
@@ -13,7 +13,7 @@ import {
   compileImagePromptContract,
   normalizeImageReferenceBindings,
 } from '../src/image/image';
-import { generateVideo, buildAtlasCreateRequest, buildSeedanceCreateRequest, validateDownloadedVideo } from '../src/video/video';
+import { generateVideo, buildAtlasCreateRequest, buildMuapiCreateRequest, buildSeedanceCreateRequest, validateDownloadedVideo } from '../src/video/video';
 
 const VALID_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
@@ -116,6 +116,29 @@ describe('request builders', () => {
       { type: 'image_url', image_url: { url: 'https://x/a.png' }, role: 'reference_image' },
       { type: 'image_url', image_url: { url: 'https://x/b.png' }, role: 'reference_image' },
     ]);
+  });
+
+  it('builds MuAPI text-to-video and image-to-video requests with endpoint overrides', () => {
+    const t2v = buildMuapiCreateRequest(
+      { provider: 'muapi', api_key: 'mu-key' },
+      { prompt: 'a dog running', output: 'out.mp4' },
+    );
+    expect(t2v.url).toBe('https://api.muapi.ai/api/v1/kling-v2.1-master-t2v');
+    expect(t2v.headers['x-api-key']).toBe('mu-key');
+    expect(t2v.body).toMatchObject({ prompt: 'a dog running', aspect_ratio: '16:9', duration: 5 });
+    expect(t2v.body).not.toHaveProperty('image_url');
+
+    const i2v = buildMuapiCreateRequest(
+      { provider: 'muapi', api_key: 'mu-key', base_url: 'https://example.test/api/v1', model: 'custom-i2v' },
+      { prompt: 'gentle camera movement', output: 'out.mp4', image_url: 'https://example.test/frame.png', ratio: '9:16', duration: 8 },
+    );
+    expect(i2v.url).toBe('https://example.test/api/v1/custom-i2v');
+    expect(i2v.body).toMatchObject({ prompt: 'gentle camera movement', aspect_ratio: '9:16', duration: 8, image_url: 'https://example.test/frame.png' });
+
+    expect(() => buildMuapiCreateRequest(
+      { provider: 'muapi', api_key: 'mu-key', model: 'custom-t2v' },
+      { prompt: 'animate this', output: 'out.mp4', image_url: 'https://example.test/frame.png' },
+    )).toThrow(/text-to-video/);
   });
 
   it('builds video edit requests with bounded source-video references', () => {
@@ -394,6 +417,74 @@ describe('generateVideo (Atlas Cloud task + poll)', () => {
   });
 });
 
+describe('generateVideo (MuAPI task + poll)', () => {
+  it('creates a task, polls until completed, and downloads the result', async () => {
+    let polls = 0;
+    const srv = await startServer((req, res) => {
+      const url = req.url ?? '';
+      if (req.method === 'POST' && url === '/custom-t2v') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ request_id: 'mu-1', status: 'processing' }));
+      } else if (req.method === 'GET' && url === '/predictions/mu-1/result') {
+        polls += 1;
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(polls < 2 ? { status: 'processing' } : { status: 'completed', outputs: [`${srv.baseUrl}/mu.mp4`] }));
+      } else if (req.method === 'GET' && url === '/mu.mp4') {
+        res.writeHead(200, { 'content-type': 'video/mp4' });
+        res.end(VALID_MP4);
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    try {
+      const out = join(dir, 'muapi.mp4');
+      const result = await generateVideo(
+        { prompt: 'a dog running', output: out, ratio: '9:16', duration: 8 },
+        { video: { provider: 'muapi', base_url: srv.baseUrl, api_key: 'mu-key', model: 'custom-t2v' } },
+        { pollIntervalMs: 1 },
+      );
+      expect(result.task_id).toBe('mu-1');
+      expect(polls).toBe(2);
+      expect(readFileSync(result.output)).toEqual(VALID_MP4);
+      const create = srv.requests.find((x) => x.method === 'POST')!;
+      expect(create.headers['x-api-key']).toBe('mu-key');
+      expect(create.headers.authorization).toBeUndefined();
+      expect(JSON.parse(create.body)).toMatchObject({ prompt: 'a dog running', aspect_ratio: '9:16', duration: 8 });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('surfaces a MuAPI task failure without writing an output', async () => {
+    const srv = await startServer((req, res) => {
+      if (req.method === 'POST') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ request_id: 'mu-2' }));
+      } else if (req.url === '/predictions/mu-2/result') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: 'failed', error: 'content policy' }));
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    const out = join(dir, 'muapi-failed.mp4');
+    try {
+      await expect(
+        generateVideo(
+          { prompt: 'unsafe', output: out },
+          { video: { provider: 'muapi', base_url: srv.baseUrl, api_key: 'mu-key', model: 'custom-t2v' } },
+          { pollIntervalMs: 1 },
+        ),
+      ).rejects.toThrow(/task mu-2 failed: content policy/);
+      expect(existsSync(out)).toBe(false);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
 // --- config env overlay ----------------------------------------------------
 
 describe('config env overlay', () => {
@@ -410,6 +501,32 @@ describe('config env overlay', () => {
       expect(c.video).toMatchObject({ provider: 'doubao', api_key: 'vk' });
     } finally {
       for (const k of ['OVS_CONFIG_DIR', 'OVS_IMAGE_PROVIDER', 'OVS_IMAGE_API_KEY', 'OVS_VIDEO_PROVIDER', 'OVS_VIDEO_API_KEY']) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+      }
+    }
+  });
+
+  it('selects MuAPI from MUAPI_API_KEY when no video provider is otherwise configured', () => {
+    const prev = { ...process.env };
+    process.env.OVS_CONFIG_DIR = dir;
+    delete process.env.OVS_VIDEO_PROVIDER;
+    delete process.env.OVS_VIDEO_API_KEY;
+    process.env.MUAPI_API_KEY = 'mu-key';
+    try {
+      const c = loadConfig();
+      expect(c.video).toMatchObject({ provider: 'muapi', api_key: 'mu-key' });
+
+      const configDir = mkdtempSync(join(tmpdir(), 'ovs-muapi-config-'));
+      try {
+        writeFileSync(join(configDir, 'config.json'), JSON.stringify({ video: { provider: 'muapi' } }));
+        process.env.OVS_CONFIG_DIR = configDir;
+        expect(loadConfig().video).toMatchObject({ provider: 'muapi', api_key: 'mu-key' });
+      } finally {
+        rmSync(configDir, { recursive: true, force: true });
+      }
+    } finally {
+      for (const k of ['OVS_CONFIG_DIR', 'OVS_VIDEO_PROVIDER', 'OVS_VIDEO_API_KEY', 'MUAPI_API_KEY']) {
         if (prev[k] === undefined) delete process.env[k];
         else process.env[k] = prev[k];
       }


### PR DESCRIPTION
## Summary

- add MuAPI as a first-class BYO video provider
- submit and poll MuAPI generation jobs, then validate and save the returned MP4
- support text-to-video and an optional first-frame image-to-video request
- support `MUAPI_API_KEY`, endpoint/model overrides, and the existing CLI/MCP video surfaces
- validate the supported Kling v2.1 request shapes before any billable submission
- keep provider-neutral plan fields compatible while omitting controls unsupported by Kling

## Configuration

Set `video.provider` to `"muapi"` and provide `MUAPI_API_KEY` (or use the existing
`OVS_VIDEO_API_KEY` override). The default endpoint is `https://api.muapi.ai/api/v1`.
Text-to-video defaults to `kling-v2.1-master-t2v`, and a first-frame image defaults to
`kling-v2.1-master-i2v`. Supported endpoint slugs are validated against their known
Kling v2.1 schemas; unsupported slugs fail locally instead of receiving a mismatched body.
See the [MuAPI API reference](https://muapi.ai/docs/api-reference) for the submit-and-poll
contract.

The adapter exposes the common prompt, aspect-ratio, duration, and first-frame inputs.
For the supported Kling endpoints, duration is 5 or 10 seconds and ratio is `16:9`,
`9:16`, or `1:1`. Provider-neutral resolution and audio fields are accepted for signed
plan compatibility but are not sent because Kling does not expose those controls; quality
is validated but not sent.

## Verification

- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test` (251 passed, 10 skipped)
- `corepack pnpm vitest run packages/tools/test/gen.test.ts` (31 passed)
- `git diff --check`

No live provider request or credentials are included in the change.
